### PR TITLE
Куликов Артём. Задача 3. Вариант 26. Линейная фильтрация изображений (горизонтальное разбиение). Ядро Гаусса 3x3.

### DIFF
--- a/tasks/task_3/kulikov_a_gauss_hor/CMakeLists.txt
+++ b/tasks/task_3/kulikov_a_gauss_hor/CMakeLists.txt
@@ -1,0 +1,38 @@
+get_filename_component(ProjectId ${CMAKE_CURRENT_SOURCE_DIR} NAME)
+enable_testing()
+
+if( USE_MPI )
+    if( UNIX )
+        set(CMAKE_C_FLAGS  "${CMAKE_CXX_FLAGS} -Wno-uninitialized")
+        set(CMAKE_CXX_FLAGS  "${CMAKE_CXX_FLAGS} -Wno-uninitialized")
+    endif( UNIX )
+
+    set(ProjectId "${ProjectId}_mpi")
+    project( ${ProjectId} )
+    message( STATUS "-- " ${ProjectId} )
+
+    file(GLOB_RECURSE ALL_SOURCE_FILES *.cpp *.h)
+
+    set(PACK_LIB "${ProjectId}_lib")
+    add_library(${PACK_LIB} STATIC ${ALL_SOURCE_FILES} )
+
+    add_executable( ${ProjectId} ${ALL_SOURCE_FILES} )
+
+    target_link_libraries(${ProjectId} ${PACK_LIB})
+    if( MPI_COMPILE_FLAGS )
+        set_target_properties( ${ProjectId} PROPERTIES COMPILE_FLAGS "${MPI_COMPILE_FLAGS}" )
+    endif( MPI_COMPILE_FLAGS )
+
+    if( MPI_LINK_FLAGS )
+        set_target_properties( ${ProjectId} PROPERTIES LINK_FLAGS "${MPI_LINK_FLAGS}" )
+    endif( MPI_LINK_FLAGS )
+    target_link_libraries( ${ProjectId} ${MPI_LIBRARIES} )
+    target_link_libraries(${ProjectId} gtest gtest_main boost_mpi)
+
+    enable_testing()
+    add_test(NAME ${ProjectId} COMMAND ${ProjectId})
+
+    CPPCHECK_AND_COUNTS_TESTS("${ProjectId}" "${ALL_SOURCE_FILES}")
+else( USE_MPI )
+    message( STATUS "-- ${ProjectId} - NOT BUILD!"  )
+endif( USE_MPI )

--- a/tasks/task_3/kulikov_a_gauss_hor/gauss_hor.cpp
+++ b/tasks/task_3/kulikov_a_gauss_hor/gauss_hor.cpp
@@ -70,7 +70,8 @@ std::vector<uint8_t> getExtPicture(int n, int m) {
     return pic;
 }
 
-std::vector<uint8_t> getParallelGauss(const std::vector<uint8_t>& orig, const std::vector<double>& kernel, int n, int m) {
+std::vector<uint8_t> getParallelGauss(const std::vector<uint8_t>& orig,
+                                        const std::vector<double>& kernel, int n, int m) {
     boost::mpi::communicator world;
     int rank = world.rank(), p = world.size();
     int delta = (n - 2) / p;
@@ -125,7 +126,8 @@ std::vector<uint8_t> getParallelGauss(const std::vector<uint8_t>& orig, const st
 
 
 
-std::vector<uint8_t> getSequentialGauss(const std::vector<uint8_t>& orig, const std::vector<double>& kernel, int n) {
+std::vector<uint8_t> getSequentialGauss(const std::vector<uint8_t>& orig,
+                                        const std::vector<double>& kernel, int n) {
     uint8_t* row;
     const uint8_t * row_cpy;
     int m = orig.size() / n, idx;

--- a/tasks/task_3/kulikov_a_gauss_hor/gauss_hor.cpp
+++ b/tasks/task_3/kulikov_a_gauss_hor/gauss_hor.cpp
@@ -17,7 +17,7 @@ uint32_t getPxSum(const std::vector<uint8_t>& pic, int n) {
 }
 
 inline uint8_t clamp(double v) {
-	return std::min<double>(std::max<double>(v, 0), uint8_t(-1));
+    return std::min<double>(std::max<double>(v, 0), uint8_t(-1));
 }
 
 double gaussPdfExp(double x_sqruare, double sd) {

--- a/tasks/task_3/kulikov_a_gauss_hor/gauss_hor.cpp
+++ b/tasks/task_3/kulikov_a_gauss_hor/gauss_hor.cpp
@@ -1,0 +1,145 @@
+// Copyright 2023 Kulikov Artem
+#include <vector>
+#include <string>
+#include <random>
+#include <algorithm>
+#include <functional>
+#include <boost/mpi/collectives.hpp>
+#include <boost/mpi/communicator.hpp>
+#include "task_3/kulikov_a_gauss_hor/gauss_hor.h"
+
+uint32_t getPxSum(std::vector<uint8_t>& pic, int n) {
+    uint32_t sum = 0;
+    for (int i = 1; i < n - 1; i++)
+        for (int j = 1; j < n - 1; j++)
+            sum += pic[i*n + j];
+    return sum;
+}
+
+inline uint8_t clamp(double v) {
+	return std::min<double>(std::max<double>(v, 0), uint8_t(-1));
+}
+
+double gaussPdfExp(double x_sqruare, double sd) {
+    double exponent = -x_sqruare;
+    exponent /= 2 * sd * sd;
+    return exp(exponent);
+}
+
+std::vector<double> get3x3GaussKernel(double sd) {
+    std::vector<double> kernel(9);
+    double norm = .0, pdf;
+    for (int i = -1; i < 1+1; i++) {
+        for (int j = -1; j < 1+1; j++) {
+            pdf = gaussPdfExp(i * i + j * j, sd);
+            kernel[(1+i)*3 + 1+j] = pdf;
+            norm += pdf;
+        }
+    }
+    for (int i = 0; i < 3; i++) {
+        for (int j = 0; j < 3; j++) {
+            kernel[i * 3 + j] /= norm;
+        }
+    }
+    return kernel;
+}
+
+std::vector<uint8_t> getExtPicture(int n) {
+    int ext_sz = n + 2;
+    std::random_device dev;
+    std::mt19937 gen(dev());
+    std::vector<uint8_t> pic(ext_sz * ext_sz);
+    for (int i = 1; i < ext_sz - 1; i++) {
+        for (int j = 1; j < ext_sz - 1; j++) {
+            pic[i * ext_sz + j] = gen() % uint8_t(-1);
+        }
+    }
+
+    for (int i = 0; i < ext_sz-1; i++) {
+        pic[1+i] = pic[1+i + ext_sz];
+        pic[ext_sz * ext_sz - 1 - (1+i)] = pic[ext_sz * ext_sz - 1 - (1+i + ext_sz)];
+        pic[(i + 2) * ext_sz - 1] = pic[(i + 2) * ext_sz - 1 - 1];
+        pic[(ext_sz -2 - i) * ext_sz] = pic[(ext_sz -2 - i) * ext_sz + 1];
+    }
+
+    return pic;
+}
+
+std::vector<uint8_t> getParallelGauss(std::vector<uint8_t>& orig, std::vector<double>& kernel, int n) {
+    boost::mpi::communicator world;
+    int rank = world.rank(), p = world.size();
+    int delta = (n - 2) / p;
+    std::vector<uint8_t> row(n * (delta + 2));
+    std::vector<uint8_t> result;
+    std::vector<int> sizes;
+    std::vector<int> displs(p);
+
+    if (world.rank() == 0) {
+        sizes = std::vector<int>(p, row.size());
+        displs = std::vector<int>(p);
+        int d = p;
+        while (displs[d] = (--d) * n * delta);
+    }
+    boost::mpi::scatterv(world, orig, sizes, displs, row.data(), row.size(), 0);
+    if (world.rank() == 0) {
+        result.resize(n * n);
+        std::copy(orig.begin(), orig.begin() + n, result.begin());
+        std::copy(orig.rbegin(), orig.rbegin() + n, result.rbegin());
+        std::copy(orig.begin(), orig.begin() + row.size(), row.begin());
+        // row = std::vector<uint8_t>(orig.begin(), orig.begin() + row.size());
+    }
+    std::vector<uint8_t> row_cpy(row);
+    int idx;
+    for (int j = 0; j < delta; j++) {
+        for (int i = 1; i < n-1; i++) {
+            idx = n*(j+1) + i;
+            row[idx] = clamp(
+                kernel[0] * row_cpy[idx - n -1] + 
+                kernel[1] * row_cpy[idx - n] +
+                kernel[2] * row_cpy[idx - n +1] + 
+                    
+                kernel[3] * row_cpy[idx -1] +
+                kernel[4] * row_cpy[idx] + 
+                kernel[5] * row_cpy[idx +1] + 
+
+                kernel[6] * row_cpy[idx + n -1] +
+                kernel[7] * row_cpy[idx + n] + 
+                kernel[8] * row_cpy[idx + n +1]);
+        }
+    }
+    if (world.rank() == 0) {
+        for (int i = 0; i < p; i++) {
+            sizes[i] -= 2 * n;
+            displs[i] += n;
+        }
+    }
+    boost::mpi::gatherv(world, row.data() + n, n * delta, result.data(), sizes, displs, 0);
+    return result;
+}
+
+
+
+
+std::vector<uint8_t> getSequentialGauss(std::vector<uint8_t>& orig, std::vector<double>& kernel, int n) {
+    uint8_t* row, * row_cpy;
+    std::vector<uint8_t> result(orig);
+    for (int j = 0; j < n-2; j++) {
+        row = result.data() + j * n;
+        row_cpy = orig.data() + j * n;
+        for (int i = 1; i < n-1; i++) {
+            row[n + i] = clamp(
+                kernel[0] * row_cpy[n + i - n -1] + 
+                kernel[1] * row_cpy[n + i - n] +
+                kernel[2] * row_cpy[n + i - n +1] + 
+                    
+                kernel[3] * row_cpy[n + i -1] +
+                kernel[4] * row_cpy[n + i] + 
+                kernel[5] * row_cpy[n + i +1] + 
+
+                kernel[6] * row_cpy[n + i + n -1] +
+                kernel[7] * row_cpy[n + i + n] + 
+                kernel[8] * row_cpy[n + i + n +1]);
+        } 
+    }
+    return result;
+}

--- a/tasks/task_3/kulikov_a_gauss_hor/gauss_hor.cpp
+++ b/tasks/task_3/kulikov_a_gauss_hor/gauss_hor.cpp
@@ -9,10 +9,11 @@
 #include "task_3/kulikov_a_gauss_hor/gauss_hor.h"
 
 uint32_t getPxSum(const std::vector<uint8_t>& pic, int n) {
+    int m = pic.size() / n;
     uint32_t sum = 0;
     for (int i = 1; i < n - 1; i++)
-        for (int j = 1; j < n - 1; j++)
-            sum += pic[i*n + j];
+        for (int j = 1; j < m - 1; j++)
+            sum += pic[i*m + j];
     return sum;
 }
 
@@ -44,32 +45,36 @@ std::vector<double> get3x3GaussKernel(double sd) {
     return kernel;
 }
 
-std::vector<uint8_t> getExtPicture(int n) {
-    int ext_sz = n + 2;
+std::vector<uint8_t> getExtPicture(int n, int m) {
+    int ext_n_sz = n + 2;
+    int ext_m_sz = m + 2;
     std::random_device dev;
     std::mt19937 gen(dev());
-    std::vector<uint8_t> pic(ext_sz * ext_sz);
-    for (int i = 1; i < ext_sz - 1; i++) {
-        for (int j = 1; j < ext_sz - 1; j++) {
-            pic[i * ext_sz + j] = gen() % uint8_t(-1);
+    std::vector<uint8_t> pic(ext_n_sz * ext_m_sz);
+    for (int i = 1; i < ext_n_sz - 1; i++) {
+        for (int j = 1; j < ext_m_sz - 1; j++) {
+            pic[i * ext_m_sz + j] = gen() % uint8_t(-1);
         }
     }
 
-    for (int i = 0; i < ext_sz-1; i++) {
-        pic[1+i] = pic[1+i + ext_sz];
-        pic[ext_sz * ext_sz - 1 - (1+i)] = pic[ext_sz * ext_sz - 1 - (1+i + ext_sz)];
-        pic[(i + 2) * ext_sz - 1] = pic[(i + 2) * ext_sz - 1 - 1];
-        pic[(ext_sz -2 - i) * ext_sz] = pic[(ext_sz -2 - i) * ext_sz + 1];
+    for (int i = 0; i < ext_n_sz-2; i++) {
+        pic[(i + 2) * ext_m_sz - 1] = pic[(i + 2) * ext_m_sz - 1 - 1];
+        pic[(ext_n_sz -2 - i) * ext_m_sz] = pic[(ext_n_sz -2 - i) * ext_m_sz + 1];
+    }
+
+    for (int i = 0; i < ext_m_sz; i++) {
+        pic[i] = pic[i + ext_m_sz];
+        pic[ext_n_sz * ext_m_sz - 1 - i] = pic[ext_n_sz * ext_m_sz - 1 - i - ext_m_sz];
     }
 
     return pic;
 }
 
-std::vector<uint8_t> getParallelGauss(const std::vector<uint8_t>& orig, const std::vector<double>& kernel, int n) {
+std::vector<uint8_t> getParallelGauss(const std::vector<uint8_t>& orig, const std::vector<double>& kernel, int n, int m) {
     boost::mpi::communicator world;
     int rank = world.rank(), p = world.size();
     int delta = (n - 2) / p;
-    std::vector<uint8_t> row(n * (delta + 2));
+    std::vector<uint8_t> row(m * (delta + 2));
     std::vector<uint8_t> result;
     std::vector<int> sizes;
     std::vector<int> displs(p);
@@ -78,42 +83,42 @@ std::vector<uint8_t> getParallelGauss(const std::vector<uint8_t>& orig, const st
         sizes = std::vector<int>(p, row.size());
         displs = std::vector<int>(p);
         int d = p;
-        while (displs[d] = (--d) * n * delta) {}
+        while (displs[d] = (--d) * m * delta) {}
     }
     boost::mpi::scatterv(world, orig, sizes, displs, row.data(), row.size(), 0);
     if (world.rank() == 0) {
-        result.resize(n * n);
-        std::copy(orig.begin(), orig.begin() + n, result.begin());
-        std::copy(orig.rbegin(), orig.rbegin() + n, result.rbegin());
+        result.resize(orig.size());
+        std::copy(orig.begin(), orig.begin() + m, result.begin());
+        std::copy(orig.rbegin(), orig.rbegin() + m, result.rbegin());
         std::copy(orig.begin(), orig.begin() + row.size(), row.begin());
         // row = std::vector<uint8_t>(orig.begin(), orig.begin() + row.size());
     }
     std::vector<uint8_t> row_cpy(row);
     int idx;
     for (int j = 0; j < delta; j++) {
-        for (int i = 1; i < n-1; i++) {
-            idx = n*(j+1) + i;
+        for (int i = 1; i < m-1; i++) {
+            idx = m*(j+1) + i;
             row[idx] = clamp(
-                kernel[0] * row_cpy[idx - n -1] +
-                kernel[1] * row_cpy[idx - n] +
-                kernel[2] * row_cpy[idx - n +1] +
+                kernel[0] * row_cpy[idx - m -1] +
+                kernel[1] * row_cpy[idx - m] +
+                kernel[2] * row_cpy[idx - m +1] +
 
                 kernel[3] * row_cpy[idx -1] +
                 kernel[4] * row_cpy[idx] +
                 kernel[5] * row_cpy[idx +1] +
 
-                kernel[6] * row_cpy[idx + n -1] +
-                kernel[7] * row_cpy[idx + n] +
-                kernel[8] * row_cpy[idx + n +1]);
+                kernel[6] * row_cpy[idx + m -1] +
+                kernel[7] * row_cpy[idx + m] +
+                kernel[8] * row_cpy[idx + m +1]);
         }
     }
     if (world.rank() == 0) {
         for (int i = 0; i < p; i++) {
-            sizes[i] -= 2 * n;
-            displs[i] += n;
+            sizes[i] -= 2 * m;
+            displs[i] += m;
         }
     }
-    boost::mpi::gatherv(world, row.data() + n, n * delta, result.data(), sizes, displs, 0);
+    boost::mpi::gatherv(world, row.data() + m, m * delta, result.data(), sizes, displs, 0);
     return result;
 }
 
@@ -123,23 +128,25 @@ std::vector<uint8_t> getParallelGauss(const std::vector<uint8_t>& orig, const st
 std::vector<uint8_t> getSequentialGauss(const std::vector<uint8_t>& orig, const std::vector<double>& kernel, int n) {
     uint8_t* row;
     const uint8_t * row_cpy;
+    int m = orig.size() / n, idx;
     std::vector<uint8_t> result(orig);
     for (int j = 0; j < n-2; j++) {
-        row = result.data() + j * n;
-        row_cpy = orig.data() + j * n;
-        for (int i = 1; i < n-1; i++) {
-            row[n + i] = clamp(
-                kernel[0] * row_cpy[n + i - n -1] +
-                kernel[1] * row_cpy[n + i - n] +
-                kernel[2] * row_cpy[n + i - n +1] +
+        row = result.data() + j * m;
+        row_cpy = orig.data() + j * m;
+        for (int i = 1; i < m-1; i++) {
+            idx = m + i;
+            row[idx] = clamp(
+                kernel[0] * row_cpy[idx - m -1] +
+                kernel[1] * row_cpy[idx - m] +
+                kernel[2] * row_cpy[idx - m +1] +
 
-                kernel[3] * row_cpy[n + i -1] +
-                kernel[4] * row_cpy[n + i] +
-                kernel[5] * row_cpy[n + i +1] +
+                kernel[3] * row_cpy[idx -1] +
+                kernel[4] * row_cpy[idx] +
+                kernel[5] * row_cpy[idx +1] +
 
-                kernel[6] * row_cpy[n + i + n -1] +
-                kernel[7] * row_cpy[n + i + n] +
-                kernel[8] * row_cpy[n + i + n +1]);
+                kernel[6] * row_cpy[idx + m -1] +
+                kernel[7] * row_cpy[idx + m] +
+                kernel[8] * row_cpy[idx + m +1]);
         }
     }
     return result;

--- a/tasks/task_3/kulikov_a_gauss_hor/gauss_hor.cpp
+++ b/tasks/task_3/kulikov_a_gauss_hor/gauss_hor.cpp
@@ -8,7 +8,7 @@
 #include <boost/mpi/communicator.hpp>
 #include "task_3/kulikov_a_gauss_hor/gauss_hor.h"
 
-uint32_t getPxSum(std::vector<uint8_t>& pic, int n) {
+uint32_t getPxSum(const std::vector<uint8_t>& pic, int n) {
     uint32_t sum = 0;
     for (int i = 1; i < n - 1; i++)
         for (int j = 1; j < n - 1; j++)
@@ -65,7 +65,7 @@ std::vector<uint8_t> getExtPicture(int n) {
     return pic;
 }
 
-std::vector<uint8_t> getParallelGauss(std::vector<uint8_t>& orig, std::vector<double>& kernel, int n) {
+std::vector<uint8_t> getParallelGauss(const std::vector<uint8_t>& orig, const std::vector<double>& kernel, int n) {
     boost::mpi::communicator world;
     int rank = world.rank(), p = world.size();
     int delta = (n - 2) / p;
@@ -78,7 +78,7 @@ std::vector<uint8_t> getParallelGauss(std::vector<uint8_t>& orig, std::vector<do
         sizes = std::vector<int>(p, row.size());
         displs = std::vector<int>(p);
         int d = p;
-        while (displs[d] = (--d) * n * delta);
+        while (displs[d] = (--d) * n * delta) {}
     }
     boost::mpi::scatterv(world, orig, sizes, displs, row.data(), row.size(), 0);
     if (world.rank() == 0) {
@@ -94,16 +94,16 @@ std::vector<uint8_t> getParallelGauss(std::vector<uint8_t>& orig, std::vector<do
         for (int i = 1; i < n-1; i++) {
             idx = n*(j+1) + i;
             row[idx] = clamp(
-                kernel[0] * row_cpy[idx - n -1] + 
+                kernel[0] * row_cpy[idx - n -1] +
                 kernel[1] * row_cpy[idx - n] +
-                kernel[2] * row_cpy[idx - n +1] + 
-                    
+                kernel[2] * row_cpy[idx - n +1] +
+
                 kernel[3] * row_cpy[idx -1] +
-                kernel[4] * row_cpy[idx] + 
-                kernel[5] * row_cpy[idx +1] + 
+                kernel[4] * row_cpy[idx] +
+                kernel[5] * row_cpy[idx +1] +
 
                 kernel[6] * row_cpy[idx + n -1] +
-                kernel[7] * row_cpy[idx + n] + 
+                kernel[7] * row_cpy[idx + n] +
                 kernel[8] * row_cpy[idx + n +1]);
         }
     }
@@ -120,26 +120,27 @@ std::vector<uint8_t> getParallelGauss(std::vector<uint8_t>& orig, std::vector<do
 
 
 
-std::vector<uint8_t> getSequentialGauss(std::vector<uint8_t>& orig, std::vector<double>& kernel, int n) {
-    uint8_t* row, * row_cpy;
+std::vector<uint8_t> getSequentialGauss(const std::vector<uint8_t>& orig, const std::vector<double>& kernel, int n) {
+    uint8_t* row;
+    const uint8_t * row_cpy;
     std::vector<uint8_t> result(orig);
     for (int j = 0; j < n-2; j++) {
         row = result.data() + j * n;
         row_cpy = orig.data() + j * n;
         for (int i = 1; i < n-1; i++) {
             row[n + i] = clamp(
-                kernel[0] * row_cpy[n + i - n -1] + 
+                kernel[0] * row_cpy[n + i - n -1] +
                 kernel[1] * row_cpy[n + i - n] +
-                kernel[2] * row_cpy[n + i - n +1] + 
-                    
+                kernel[2] * row_cpy[n + i - n +1] +
+
                 kernel[3] * row_cpy[n + i -1] +
-                kernel[4] * row_cpy[n + i] + 
-                kernel[5] * row_cpy[n + i +1] + 
+                kernel[4] * row_cpy[n + i] +
+                kernel[5] * row_cpy[n + i +1] +
 
                 kernel[6] * row_cpy[n + i + n -1] +
-                kernel[7] * row_cpy[n + i + n] + 
+                kernel[7] * row_cpy[n + i + n] +
                 kernel[8] * row_cpy[n + i + n +1]);
-        } 
+        }
     }
     return result;
 }

--- a/tasks/task_3/kulikov_a_gauss_hor/gauss_hor.h
+++ b/tasks/task_3/kulikov_a_gauss_hor/gauss_hor.h
@@ -1,14 +1,14 @@
 // Copyright 2023 Kulikov Artem
-#ifndef TASKS_TASK_2_KULIKOV_A_GAUSS_HOR_GAUSS_HOR_H_
-#define TASKS_TASK_2_KULIKOV_A_MIN_IN_MATR_MIN_IN_MATR_H_
+#ifndef TASKS_TASK_3_KULIKOV_A_GAUSS_HOR_GAUSS_HOR_H_
+#define TASKS_TASK_3_KULIKOV_A_GAUSS_HOR_GAUSS_HOR_H_
 
 #include <vector>
 #include <boost/serialization/vector.hpp>
 
 std::vector<double> get3x3GaussKernel(double sd);
-uint32_t getPxSum(std::vector<uint8_t>& pic, int n);
+uint32_t getPxSum(const std::vector<uint8_t>& pic, int n);
 std::vector<uint8_t> getExtPicture(int n);
-std::vector<uint8_t> getParallelGauss(std::vector<uint8_t>& orig, std::vector<double>& kernel, int n);
-std::vector<uint8_t> getSequentialGauss(std::vector<uint8_t>& orig, std::vector<double>& kernel, int n);
+std::vector<uint8_t> getParallelGauss(const std::vector<uint8_t>& orig, const std::vector<double>& kernel, int n);
+std::vector<uint8_t> getSequentialGauss(const std::vector<uint8_t>& orig, const std::vector<double>& kernel, int n);
 
-#endif  // TASKS_TASK_2_KULIKOV_A_MIN_IN_MATR_MIN_IN_MATR_H_
+#endif  // TASKS_TASK_3_KULIKOV_A_GAUSS_HOR_GAUSS_HOR_H_

--- a/tasks/task_3/kulikov_a_gauss_hor/gauss_hor.h
+++ b/tasks/task_3/kulikov_a_gauss_hor/gauss_hor.h
@@ -8,7 +8,9 @@
 std::vector<double> get3x3GaussKernel(double sd);
 uint32_t getPxSum(const std::vector<uint8_t>& pic, int n);
 std::vector<uint8_t> getExtPicture(int n, int m);
-std::vector<uint8_t> getParallelGauss(const std::vector<uint8_t>& orig, const std::vector<double>& kernel, int n, int m);
-std::vector<uint8_t> getSequentialGauss(const std::vector<uint8_t>& orig, const std::vector<double>& kernel, int n);
+std::vector<uint8_t> getParallelGauss(const std::vector<uint8_t>& orig,
+                                        const std::vector<double>& kernel, int n, int m);
+std::vector<uint8_t> getSequentialGauss(const std::vector<uint8_t>& orig,
+                                        const std::vector<double>& kernel, int n);
 
 #endif  // TASKS_TASK_3_KULIKOV_A_GAUSS_HOR_GAUSS_HOR_H_

--- a/tasks/task_3/kulikov_a_gauss_hor/gauss_hor.h
+++ b/tasks/task_3/kulikov_a_gauss_hor/gauss_hor.h
@@ -7,8 +7,8 @@
 
 std::vector<double> get3x3GaussKernel(double sd);
 uint32_t getPxSum(const std::vector<uint8_t>& pic, int n);
-std::vector<uint8_t> getExtPicture(int n);
-std::vector<uint8_t> getParallelGauss(const std::vector<uint8_t>& orig, const std::vector<double>& kernel, int n);
+std::vector<uint8_t> getExtPicture(int n, int m);
+std::vector<uint8_t> getParallelGauss(const std::vector<uint8_t>& orig, const std::vector<double>& kernel, int n, int m);
 std::vector<uint8_t> getSequentialGauss(const std::vector<uint8_t>& orig, const std::vector<double>& kernel, int n);
 
 #endif  // TASKS_TASK_3_KULIKOV_A_GAUSS_HOR_GAUSS_HOR_H_

--- a/tasks/task_3/kulikov_a_gauss_hor/gauss_hor.h
+++ b/tasks/task_3/kulikov_a_gauss_hor/gauss_hor.h
@@ -1,0 +1,14 @@
+// Copyright 2023 Kulikov Artem
+#ifndef TASKS_TASK_2_KULIKOV_A_GAUSS_HOR_GAUSS_HOR_H_
+#define TASKS_TASK_2_KULIKOV_A_MIN_IN_MATR_MIN_IN_MATR_H_
+
+#include <vector>
+#include <boost/serialization/vector.hpp>
+
+std::vector<double> get3x3GaussKernel(double sd);
+uint32_t getPxSum(std::vector<uint8_t>& pic, int n);
+std::vector<uint8_t> getExtPicture(int n);
+std::vector<uint8_t> getParallelGauss(std::vector<uint8_t>& orig, std::vector<double>& kernel, int n);
+std::vector<uint8_t> getSequentialGauss(std::vector<uint8_t>& orig, std::vector<double>& kernel, int n);
+
+#endif  // TASKS_TASK_2_KULIKOV_A_MIN_IN_MATR_MIN_IN_MATR_H_

--- a/tasks/task_3/kulikov_a_gauss_hor/main.cpp
+++ b/tasks/task_3/kulikov_a_gauss_hor/main.cpp
@@ -102,10 +102,10 @@ TEST(Parallel_Gaussian_Filter, Test_Horizontal_Crosses_Small_Sd) {
 
     if (world.rank() == 0) {
         pic = {
-         255, 255, 255, 255, 255, 255,  
+         255, 255, 255, 255, 255, 255,
          255, 255, 255, 255, 255, 255,
          0,     0, 255,   0, 255, 255,
-         255, 255,   0, 255, 255, 255, 
+         255, 255,   0, 255, 255, 255,
          0,    0,  255,   0, 255, 255,
          0,    0,  255,   0, 255, 255
         };
@@ -115,14 +115,14 @@ TEST(Parallel_Gaussian_Filter, Test_Horizontal_Crosses_Small_Sd) {
 
     if (world.rank() == 0) {
         std::vector<uint8_t> sec_filtered = {
-            255, 255, 255, 255, 255, 255,  
+            255, 255, 255, 255, 255, 255,
             255, 254, 254, 254, 254, 255,
             0,     0, 254,   0, 254, 255,
-            255, 254,   0, 254, 254, 255, 
+            255, 254,   0, 254, 254, 255,
             0,     0, 254,   0, 254, 255,
             0,     0, 255,   0, 255, 255
         };
-        
+
         for (int i = 0; i < n + 2; i++) {
             for (int j = 0; j < n + 2; j++) {
                 ASSERT_EQ(filetered_pic[i * (n + 2) + j], sec_filtered[i * (n + 2) + j]);

--- a/tasks/task_3/kulikov_a_gauss_hor/main.cpp
+++ b/tasks/task_3/kulikov_a_gauss_hor/main.cpp
@@ -1,0 +1,144 @@
+// Copyright 2023 Kulikov Artem
+#include <gtest/gtest.h>
+#include <vector>
+#include <iostream>
+
+#include <boost/mpi/communicator.hpp>
+#include <boost/mpi/environment.hpp>
+#include <boost/serialization/vector.hpp>
+
+#include "./gauss_hor.h"
+
+
+TEST(Parallel_Gaussian_Filter, Test_Size) {
+    boost::mpi::communicator world;
+    int n = 4;
+    std::vector<double> kern = get3x3GaussKernel(1.0);
+    std::vector<uint8_t> pic;
+
+
+    if (world.rank() == 0) {
+        pic = getExtPicture(n);
+    }
+
+    auto filetered_pic = getParallelGauss(pic, kern, n + 2);
+
+    if (world.rank() == 0) {
+        auto sec_filtered = getSequentialGauss(pic, kern, n + 2);
+        ASSERT_EQ(filetered_pic.size(), sec_filtered.size());
+    }
+}
+
+TEST(Parallel_Gaussian_Filter, Test_Intensive) {
+    boost::mpi::communicator world;
+    int n = 100;
+    std::vector<double> kern = get3x3GaussKernel(1.0);
+    std::vector<uint8_t> pic;
+    std::uint32_t orig_sum, parallel_sum;
+
+
+    if (world.rank() == 0) {
+        pic = getExtPicture(n);
+        orig_sum = getPxSum(pic, n + 2);
+    }
+
+    auto filetered_pic = getParallelGauss(pic, kern, n + 2);
+
+    if (world.rank() == 0) {
+        parallel_sum = getPxSum(filetered_pic, n + 2);
+        ASSERT_NEAR(parallel_sum, orig_sum, orig_sum*0.01);
+    }
+}
+
+TEST(Parallel_Gaussian_Filter, Test_RandValues4) {
+    boost::mpi::communicator world;
+    int n = 4;
+    std::vector<double> kern = get3x3GaussKernel(1.0);
+    std::vector<uint8_t> pic;
+
+    if (world.rank() == 0) {
+        pic = getExtPicture(n);
+    }
+
+    auto filetered_pic = getParallelGauss(pic, kern, n + 2);
+
+    if (world.rank() == 0) {
+        auto sec_filtered = getSequentialGauss(pic, kern, n + 2);
+        for (int i = 0; i < n + 2; i++) {
+            for (int j = 0; j < n + 2; j++) {
+                ASSERT_EQ(filetered_pic[i * (n + 2) + j], sec_filtered[i * (n + 2) + j]);
+            }
+        }
+    }
+}
+
+TEST(Parallel_Gaussian_Filter, Test_RandValues8) {
+    boost::mpi::communicator world;
+    int n = 8;
+    std::vector<double> kern = get3x3GaussKernel(1.0);
+    std::vector<uint8_t> pic;
+
+    if (world.rank() == 0) {
+        pic = getExtPicture(n);
+    }
+
+    auto filetered_pic = getParallelGauss(pic, kern, n + 2);
+
+    if (world.rank() == 0) {
+        auto sec_filtered = getSequentialGauss(pic, kern, n + 2);
+        for (int i = 0; i < n + 2; i++) {
+            for (int j = 0; j < n + 2; j++) {
+                ASSERT_EQ(filetered_pic[i * (n + 2) + j], sec_filtered[i * (n + 2) + j]);
+            }
+        }
+    }
+}
+
+TEST(Parallel_Gaussian_Filter, Test_Horizontal_Crosses_Small_Sd) {
+    boost::mpi::communicator world;
+    int n = 4;
+    std::vector<double> kern = get3x3GaussKernel(0.2);
+    std::vector<uint8_t> pic;
+
+    if (world.rank() == 0) {
+        pic = {
+         255, 255, 255, 255, 255, 255,  
+         255, 255, 255, 255, 255, 255,
+         0,     0, 255,   0, 255, 255,
+         255, 255,   0, 255, 255, 255, 
+         0,    0,  255,   0, 255, 255,
+         0,    0,  255,   0, 255, 255
+        };
+    }
+
+    auto filetered_pic = getParallelGauss(pic, kern, n + 2);
+
+    if (world.rank() == 0) {
+        std::vector<uint8_t> sec_filtered = {
+            255, 255, 255, 255, 255, 255,  
+            255, 254, 254, 254, 254, 255,
+            0,     0, 254,   0, 254, 255,
+            255, 254,   0, 254, 254, 255, 
+            0,     0, 254,   0, 254, 255,
+            0,     0, 255,   0, 255, 255
+        };
+        
+        for (int i = 0; i < n + 2; i++) {
+            for (int j = 0; j < n + 2; j++) {
+                ASSERT_EQ(filetered_pic[i * (n + 2) + j], sec_filtered[i * (n + 2) + j]);
+            }
+        }
+    }
+}
+
+
+int main(int argc, char** argv) {
+    boost::mpi::environment env(argc, argv);
+    boost::mpi::communicator world;
+    ::testing::InitGoogleTest(&argc, argv);
+    ::testing::TestEventListeners& listeners = ::testing::UnitTest::GetInstance()->listeners();
+    if (world.rank() != 0) {
+        delete listeners.Release(listeners.default_result_printer());
+    }
+    return RUN_ALL_TESTS();
+}

--- a/tasks/task_3/kulikov_a_gauss_hor/main.cpp
+++ b/tasks/task_3/kulikov_a_gauss_hor/main.cpp
@@ -12,16 +12,16 @@
 
 TEST(Parallel_Gaussian_Filter, Test_Size) {
     boost::mpi::communicator world;
-    int n = 4;
+    int n = 4, m = 4;
     std::vector<double> kern = get3x3GaussKernel(1.0);
     std::vector<uint8_t> pic;
 
 
     if (world.rank() == 0) {
-        pic = getExtPicture(n);
+        pic = getExtPicture(n, m);
     }
 
-    auto filetered_pic = getParallelGauss(pic, kern, n + 2);
+    auto filetered_pic = getParallelGauss(pic, kern, n + 2, m + 2);
 
     if (world.rank() == 0) {
         auto sec_filtered = getSequentialGauss(pic, kern, n + 2);
@@ -31,18 +31,18 @@ TEST(Parallel_Gaussian_Filter, Test_Size) {
 
 TEST(Parallel_Gaussian_Filter, Test_Intensive) {
     boost::mpi::communicator world;
-    int n = 100;
+    int n = 100, m = 20;
     std::vector<double> kern = get3x3GaussKernel(1.0);
     std::vector<uint8_t> pic;
     std::uint32_t orig_sum, parallel_sum;
 
 
     if (world.rank() == 0) {
-        pic = getExtPicture(n);
+        pic = getExtPicture(n, m);
         orig_sum = getPxSum(pic, n + 2);
     }
 
-    auto filetered_pic = getParallelGauss(pic, kern, n + 2);
+    auto filetered_pic = getParallelGauss(pic, kern, n + 2, m + 2);
 
     if (world.rank() == 0) {
         parallel_sum = getPxSum(filetered_pic, n + 2);
@@ -52,21 +52,21 @@ TEST(Parallel_Gaussian_Filter, Test_Intensive) {
 
 TEST(Parallel_Gaussian_Filter, Test_RandValues4) {
     boost::mpi::communicator world;
-    int n = 4;
+    int n = 4, m = 2;
     std::vector<double> kern = get3x3GaussKernel(1.0);
     std::vector<uint8_t> pic;
 
     if (world.rank() == 0) {
-        pic = getExtPicture(n);
+        pic = getExtPicture(n, m);
     }
 
-    auto filetered_pic = getParallelGauss(pic, kern, n + 2);
+    auto filetered_pic = getParallelGauss(pic, kern, n + 2, m + 2);
 
     if (world.rank() == 0) {
         auto sec_filtered = getSequentialGauss(pic, kern, n + 2);
         for (int i = 0; i < n + 2; i++) {
-            for (int j = 0; j < n + 2; j++) {
-                ASSERT_EQ(filetered_pic[i * (n + 2) + j], sec_filtered[i * (n + 2) + j]);
+            for (int j = 0; j < m + 2; j++) {
+                ASSERT_EQ(filetered_pic[i * (m + 2) + j], sec_filtered[i * (m + 2) + j]);
             }
         }
     }
@@ -74,21 +74,21 @@ TEST(Parallel_Gaussian_Filter, Test_RandValues4) {
 
 TEST(Parallel_Gaussian_Filter, Test_RandValues8) {
     boost::mpi::communicator world;
-    int n = 8;
+    int n = 8, m = 7;
     std::vector<double> kern = get3x3GaussKernel(1.0);
     std::vector<uint8_t> pic;
 
     if (world.rank() == 0) {
-        pic = getExtPicture(n);
+        pic = getExtPicture(n, m);
     }
 
-    auto filetered_pic = getParallelGauss(pic, kern, n + 2);
+    auto filetered_pic = getParallelGauss(pic, kern, n + 2, m + 2);
 
     if (world.rank() == 0) {
         auto sec_filtered = getSequentialGauss(pic, kern, n + 2);
         for (int i = 0; i < n + 2; i++) {
-            for (int j = 0; j < n + 2; j++) {
-                ASSERT_EQ(filetered_pic[i * (n + 2) + j], sec_filtered[i * (n + 2) + j]);
+            for (int j = 0; j < m + 2; j++) {
+                ASSERT_EQ(filetered_pic[i * (m + 2) + j], sec_filtered[i * (m + 2) + j]);
             }
         }
     }
@@ -96,7 +96,7 @@ TEST(Parallel_Gaussian_Filter, Test_RandValues8) {
 
 TEST(Parallel_Gaussian_Filter, Test_Horizontal_Crosses_Small_Sd) {
     boost::mpi::communicator world;
-    int n = 4;
+    int n = 4, m = 4;
     std::vector<double> kern = get3x3GaussKernel(0.2);
     std::vector<uint8_t> pic;
 
@@ -111,7 +111,7 @@ TEST(Parallel_Gaussian_Filter, Test_Horizontal_Crosses_Small_Sd) {
         };
     }
 
-    auto filetered_pic = getParallelGauss(pic, kern, n + 2);
+    auto filetered_pic = getParallelGauss(pic, kern, n + 2, m + 2);
 
     if (world.rank() == 0) {
         std::vector<uint8_t> sec_filtered = {
@@ -124,8 +124,8 @@ TEST(Parallel_Gaussian_Filter, Test_Horizontal_Crosses_Small_Sd) {
         };
 
         for (int i = 0; i < n + 2; i++) {
-            for (int j = 0; j < n + 2; j++) {
-                ASSERT_EQ(filetered_pic[i * (n + 2) + j], sec_filtered[i * (n + 2) + j]);
+            for (int j = 0; j < m + 2; j++) {
+                ASSERT_EQ(filetered_pic[i * (m + 2) + j], sec_filtered[i * (m + 2) + j]);
             }
         }
     }


### PR DESCRIPTION
Фильтрация ядром Гаусса используется для блюра изображения и как подготовительная стадия для алгоритмов выделения границ.
Изображение, набор байт (значения от 0 до 255), подаётся на вход уже в расширенном виде для того, чтобы у крайних пикселе были соседи в квадрате 3х3. Рамка заполняется значениями краевых пикселей.
`n x m` - изображение. `delta` = n / world.size() - кол-во строчек для обработки на каждом процессе.
Для обработки `delta` строчек нам нужно `delta + 2` строчки из расширенного изображения. Таким образом передача данных осуществляется с перекрытием - поэтому для учёта сдвигов при распределении данных нам нужен `scatterv`. Отдавать с процессов мы будем только `delta` строчек, используя по тем же причинам `gatherv`.