### PR TITLE
Захаров Артем. Задача 3. Вариант 7. Вычисление многомерных интегралов с использованием многошаговой схемы  (метод прямоугольников).

### DIFF
--- a/tasks/task_3/zakharov_a_multiple_integral_rec/CMakeLists.txt
+++ b/tasks/task_3/zakharov_a_multiple_integral_rec/CMakeLists.txt
@@ -1,0 +1,38 @@
+get_filename_component(ProjectId ${CMAKE_CURRENT_SOURCE_DIR} NAME)
+enable_testing()
+
+if( USE_MPI )
+    if( UNIX )
+        set(CMAKE_C_FLAGS  "${CMAKE_CXX_FLAGS} -Wno-uninitialized")
+        set(CMAKE_CXX_FLAGS  "${CMAKE_CXX_FLAGS} -Wno-uninitialized")
+    endif( UNIX )
+
+    set(ProjectId "${ProjectId}_mpi")
+    project( ${ProjectId} )
+    message( STATUS "-- " ${ProjectId} )
+
+    file(GLOB_RECURSE ALL_SOURCE_FILES *.cpp *.h)
+
+    set(PACK_LIB "${ProjectId}_lib")
+    add_library(${PACK_LIB} STATIC ${ALL_SOURCE_FILES} )
+
+    add_executable( ${ProjectId} ${ALL_SOURCE_FILES} )
+
+    target_link_libraries(${ProjectId} ${PACK_LIB})
+    if( MPI_COMPILE_FLAGS )
+        set_target_properties( ${ProjectId} PROPERTIES COMPILE_FLAGS "${MPI_COMPILE_FLAGS}" )
+    endif( MPI_COMPILE_FLAGS )
+
+    if( MPI_LINK_FLAGS )
+        set_target_properties( ${ProjectId} PROPERTIES LINK_FLAGS "${MPI_LINK_FLAGS}" )
+    endif( MPI_LINK_FLAGS )
+    target_link_libraries( ${ProjectId} ${MPI_LIBRARIES} )
+    target_link_libraries(${ProjectId} gtest gtest_main boost_mpi)
+
+    enable_testing()
+    add_test(NAME ${ProjectId} COMMAND ${ProjectId})
+
+    CPPCHECK_AND_COUNTS_TESTS("${ProjectId}" "${ALL_SOURCE_FILES}")
+else( USE_MPI )
+    message( STATUS "-- ${ProjectId} - NOT BUILD!"  )
+endif( USE_MPI )

--- a/tasks/task_3/zakharov_a_multiple_integral_rec/main.cpp
+++ b/tasks/task_3/zakharov_a_multiple_integral_rec/main.cpp
@@ -82,7 +82,7 @@ TEST(Parallel_Integral, Test_Two_Var) {
     std::vector<std::pair<double, double>> lim_integ = {};
     double epsilon = 1e-6;
     if (world.rank() == 0) {
-        lim_integ = {get_random_lim(-3, 13), get_random_lim(5, 32)};
+        lim_integ = {get_random_lim(-3, 13), get_random_lim(5, 22)};
     }
 
     double par_result = calc_integ_par(num_vars, two_var_func,

--- a/tasks/task_3/zakharov_a_multiple_integral_rec/main.cpp
+++ b/tasks/task_3/zakharov_a_multiple_integral_rec/main.cpp
@@ -11,8 +11,8 @@ TEST(Sequential_Integral, Test_One_Var) {
     if (world.rank() == 0) {
         double true_val = 1.42823590869;
         double epsilon = 1e-3;
-        size_t num_vars = 1;
-        std::vector<size_t> num_parts = {1000};
+        std::size_t num_vars = 1;
+        std::vector<std::size_t> num_parts = {1000};
         std::vector<std::pair<double, double>> lim_integ = {{-1, 15.23}};
 
         double result = calc_integ_seq(num_vars, one_var_func,
@@ -26,8 +26,8 @@ TEST(Sequential_Integral, Test_Two_Var) {
     if (world.rank() == 0) {
         double true_val = 12062.2623333;
         double epsilon = 1e-1;
-        size_t num_vars = 2;
-        std::vector<size_t> num_parts = {1000, 1000};
+        std::size_t num_vars = 2;
+        std::vector<std::size_t> num_parts = {1000, 1000};
         std::vector<std::pair<double, double>> lim_integ = {{-2.3, 4.1},
                                                             {0, 6.5}
         };
@@ -43,8 +43,8 @@ TEST(Sequential_Integral, Test_Three_Var) {
     if (world.rank() == 0) {
         double true_val = 6.23202211038;
         double epsilon = 1e-1;
-        size_t num_vars = 3;
-        std::vector<size_t> num_parts = {100, 100, 100};
+        std::size_t num_vars = 3;
+        std::vector<std::size_t> num_parts = {100, 100, 100};
         std::vector<std::pair<double, double>> lim_integ = {{1, 2},
                                                             {3.2, 5},
                                                             {6.743, 8}
@@ -58,8 +58,8 @@ TEST(Sequential_Integral, Test_Three_Var) {
 
 TEST(Parallel_Integral, Test_One_Var) {
     boost::mpi::communicator world;
-    size_t num_vars = 1;
-    std::vector<size_t> num_parts = {1000};
+    std::size_t num_vars = 1;
+    std::vector<std::size_t> num_parts = {1000};
     std::vector<std::pair<double, double>> lim_integ = {};
     double epsilon = 1e-6;
     if (world.rank() == 0) {
@@ -77,8 +77,8 @@ TEST(Parallel_Integral, Test_One_Var) {
 
 TEST(Parallel_Integral, Test_Two_Var) {
     boost::mpi::communicator world;
-    size_t num_vars = 2;
-    std::vector<size_t> num_parts = {500, 500};
+    std::size_t num_vars = 2;
+    std::vector<std::size_t> num_parts = {500, 500};
     std::vector<std::pair<double, double>> lim_integ = {};
     double epsilon = 1e-6;
     if (world.rank() == 0) {
@@ -96,8 +96,8 @@ TEST(Parallel_Integral, Test_Two_Var) {
 
 TEST(Parallel_Integral, Test_Two_Var_2) {
     boost::mpi::communicator world;
-    size_t num_vars = 2;
-    std::vector<size_t> num_parts = {500, 500};
+    std::size_t num_vars = 2;
+    std::vector<std::size_t> num_parts = {500, 500};
     std::vector<std::pair<double, double>> lim_integ = {};
     double epsilon = 1e-6;
     if (world.rank() == 0) {
@@ -115,8 +115,8 @@ TEST(Parallel_Integral, Test_Two_Var_2) {
 
 TEST(Parallel_Integral, Test_Three_Var) {
     boost::mpi::communicator world;
-    size_t num_vars = 3;
-    std::vector<size_t> num_parts = {100, 100, 100};
+    std::size_t num_vars = 3;
+    std::vector<std::size_t> num_parts = {100, 100, 100};
     std::vector<std::pair<double, double>> lim_integ = {};
     double epsilon = 1e-6;
     if (world.rank() == 0) {
@@ -137,8 +137,8 @@ TEST(Parallel_Integral, Test_Three_Var) {
 
 TEST(Parallel_Integral, Test_Four_Var) {
     boost::mpi::communicator world;
-    size_t num_vars = 4;
-    std::vector<size_t> num_parts = {28, 28, 28, 28};
+    std::size_t num_vars = 4;
+    std::vector<std::size_t> num_parts = {28, 28, 28, 28};
     std::vector<std::pair<double, double>> lim_integ = {};
     double epsilon = 1e-6;
     if (world.rank() == 0) {

--- a/tasks/task_3/zakharov_a_multiple_integral_rec/main.cpp
+++ b/tasks/task_3/zakharov_a_multiple_integral_rec/main.cpp
@@ -1,0 +1,167 @@
+// Copyright 2023 Zakharov Artem
+#include <gtest/gtest.h>
+#include <vector>
+#include "./multiple_integral.h"
+#include <boost/mpi/environment.hpp>
+#include <boost/mpi/communicator.hpp>
+#include <boost/mpi/timer.hpp>
+
+TEST(Sequential_Integral, Test_One_Var) {
+    boost::mpi::communicator world;
+    if (world.rank() == 0) {
+        double true_val = 1.42823590869;
+        double epsilon = 1e-3;
+        size_t num_vars = 1;
+        std::vector<size_t> num_parts = {1000};
+        std::vector<std::pair<double, double>> lim_integ = {{-1, 15.23}};
+
+        double result = calc_integ_seq(num_vars, one_var_func,
+                                       num_parts, lim_integ);
+        ASSERT_LT(std::abs(result - true_val), epsilon);
+    }
+}
+
+TEST(Sequential_Integral, Test_Two_Var) {
+    boost::mpi::communicator world;
+    if (world.rank() == 0) {
+        double true_val = 12062.2623333;
+        double epsilon = 1e-1;
+        size_t num_vars = 2;
+        std::vector<size_t> num_parts = {1000, 1000};
+        std::vector<std::pair<double, double>> lim_integ = {{-2.3, 4.1},
+                                                            {0, 6.5}
+        };
+
+        double result = calc_integ_seq(num_vars, two_var_func,
+                                       num_parts, lim_integ);
+        ASSERT_LT(std::abs(result - true_val), epsilon);
+    }
+}
+
+TEST(Sequential_Integral, Test_Three_Var) {
+    boost::mpi::communicator world;
+    if (world.rank() == 0) {
+        double true_val = 6.23202211038;
+        double epsilon = 1e-1;
+        size_t num_vars = 3;
+        std::vector<size_t> num_parts = {100, 100, 100};
+        std::vector<std::pair<double, double>> lim_integ = {{1, 2},
+                                                            {3.2, 5},
+                                                            {6.743, 8}
+        };
+
+        double result = calc_integ_seq(num_vars, three_var_func,
+                                       num_parts, lim_integ);
+        ASSERT_LT(std::abs(result - true_val), epsilon);
+    }
+}
+
+TEST(Parallel_Integral, Test_One_Var) {
+    boost::mpi::communicator world;
+    size_t num_vars = 1;
+    std::vector<size_t> num_parts = {1000};
+    std::vector<std::pair<double, double>> lim_integ = {};
+    double epsilon = 1e-6;
+    if (world.rank() == 0) {
+        lim_integ = {{-134.4, 45.231}};
+    }
+
+    double par_result = calc_integ_par(num_vars, one_var_func,
+                                            num_parts, &lim_integ);
+    if (world.rank() == 0) {
+        double seq_result = calc_integ_seq(num_vars, one_var_func,
+                                           num_parts, lim_integ);
+        ASSERT_LT(std::abs(par_result - seq_result), epsilon);
+    }
+}
+
+TEST(Parallel_Integral, Test_Two_Var) {
+    boost::mpi::communicator world;
+    size_t num_vars = 2;
+    std::vector<size_t> num_parts = {500, 500};
+    std::vector<std::pair<double, double>> lim_integ = {};
+    double epsilon = 1e-6;
+    if (world.rank() == 0) {
+        lim_integ = {get_random_lim(-3, 13), get_random_lim(5, 32)};
+    }
+
+    double par_result = calc_integ_par(num_vars, two_var_func,
+                                       num_parts, &lim_integ);
+    if (world.rank() == 0) {
+        double seq_result = calc_integ_seq(num_vars, two_var_func,
+                                           num_parts, lim_integ);
+        ASSERT_LT(std::abs(par_result - seq_result), epsilon);
+    }
+}
+
+TEST(Parallel_Integral, Test_Two_Var_2) {
+    boost::mpi::communicator world;
+    size_t num_vars = 2;
+    std::vector<size_t> num_parts = {500, 500};
+    std::vector<std::pair<double, double>> lim_integ = {};
+    double epsilon = 1e-6;
+    if (world.rank() == 0) {
+        lim_integ = {{13.489, 19.25}, {2.148, 4.015}};
+    }
+
+    double par_result = calc_integ_par(num_vars, two_var_func_2,
+                                       num_parts, &lim_integ);
+    if (world.rank() == 0) {
+        double seq_result = calc_integ_seq(num_vars, two_var_func_2,
+                                           num_parts, lim_integ);
+        ASSERT_LT(std::abs(par_result - seq_result), epsilon);
+    }
+}
+
+TEST(Parallel_Integral, Test_Three_Var) {
+    boost::mpi::communicator world;
+    size_t num_vars = 3;
+    std::vector<size_t> num_parts = {100, 100, 100};
+    std::vector<std::pair<double, double>> lim_integ = {};
+    double epsilon = 1e-6;
+    if (world.rank() == 0) {
+        lim_integ = {get_random_lim(0, 7),
+                     get_random_lim(5, 9),
+                     get_random_lim(23, 28)
+        };
+    }
+
+    double par_result = calc_integ_par(num_vars, three_var_func,
+                                       num_parts, &lim_integ);
+    if (world.rank() == 0) {
+        double seq_result = calc_integ_seq(num_vars, three_var_func,
+                                           num_parts, lim_integ);
+        ASSERT_LT(std::abs(par_result - seq_result), epsilon);
+    }
+}
+
+TEST(Parallel_Integral, Test_Four_Var) {
+    boost::mpi::communicator world;
+    size_t num_vars = 4;
+    std::vector<size_t> num_parts = {28, 28, 28, 28};
+    std::vector<std::pair<double, double>> lim_integ = {};
+    double epsilon = 1e-6;
+    if (world.rank() == 0) {
+        lim_integ = {{1.32, 1.98}, {72.4, 73}, {-3.2, -2.89}, {3.43, 4}};
+    }
+
+    double par_result = calc_integ_par(num_vars, four_var_func,
+                                       num_parts, &lim_integ);
+    if (world.rank() == 0) {
+        double seq_result = calc_integ_seq(num_vars, four_var_func,
+                                           num_parts, lim_integ);
+        ASSERT_LT(std::abs(par_result - seq_result), epsilon);
+    }
+}
+
+int main(int argc, char** argv) {
+    boost::mpi::environment env(argc, argv);
+    boost::mpi::communicator world;
+    ::testing::InitGoogleTest(&argc, argv);
+    ::testing::TestEventListeners& listeners =
+            ::testing::UnitTest::GetInstance()->listeners();
+    if (world.rank() != 0) {
+        delete listeners.Release(listeners.default_result_printer());
+    }
+    return RUN_ALL_TESTS();
+}

--- a/tasks/task_3/zakharov_a_multiple_integral_rec/multiple_integral.cpp
+++ b/tasks/task_3/zakharov_a_multiple_integral_rec/multiple_integral.cpp
@@ -6,8 +6,8 @@
 #include <boost/mpi/communicator.hpp>
 #include <boost/serialization/utility.hpp>
 
-double calc_integ_par(size_t num_vars, func f,
-                      const std::vector<size_t>& num_parts,
+double calc_integ_par(std::size_t num_vars, func f,
+                      const std::vector<std::size_t>& num_parts,
                       std::vector<std::pair<double, double>>* lim_integ) {
     boost::mpi::communicator comm;
     double global_res = 0;
@@ -16,14 +16,14 @@ double calc_integ_par(size_t num_vars, func f,
     boost::mpi::broadcast(comm, lim_integ->data(),
                           static_cast<int>(num_vars), 0);
 
-    size_t num_areas = get_num_areas(num_parts);
-    size_t num_local_areas = num_areas / comm.size();
+    std::size_t num_areas = get_num_areas(num_parts);
+    std::size_t num_local_areas = num_areas / comm.size();
 
     std::vector<double> steps = get_steps(num_vars, *lim_integ, num_parts);
 
     std::vector<double> vars(num_vars);
-    size_t first_area = num_local_areas * comm.rank();
-    size_t last_area = first_area + num_local_areas;
+    std::size_t first_area = num_local_areas * comm.rank();
+    std::size_t last_area = first_area + num_local_areas;
     if (comm.rank() == comm.size() - 1) {
         last_area += num_areas % comm.size();
     }
@@ -36,11 +36,11 @@ double calc_integ_par(size_t num_vars, func f,
     return global_res;
 }
 
-double calc_integ_seq(size_t num_vars, func f,
-                      const std::vector<size_t>& num_parts,
+double calc_integ_seq(std::size_t num_vars, func f,
+                      const std::vector<std::size_t>& num_parts,
                       const std::vector<
                               std::pair<double, double>>& lim_integ) {
-    size_t num_areas = get_num_areas(num_parts);
+    std::size_t num_areas = get_num_areas(num_parts);
 
     std::vector<double> steps = get_steps(num_vars, lim_integ, num_parts);
 
@@ -50,17 +50,18 @@ double calc_integ_seq(size_t num_vars, func f,
     return res;
 }
 
-double calc_val_areas(size_t first_area, size_t last_area, size_t num_vars,
-                      func f, const std::vector<size_t>& num_parts,
+double calc_val_areas(std::size_t first_area, std::size_t last_area,
+                      std::size_t num_vars, func f,
+                      const std::vector<std::size_t>& num_parts,
                       const std::vector<std::pair<double, double>>& lim_integ,
                       const std::vector<double>& steps) {
     double res = 0;
     double offset;
     std::vector<double> vars(num_vars);
-    for (size_t cur_area = first_area; cur_area < last_area; cur_area++) {
-        size_t ind_rest = cur_area;
-        for (size_t var_ind = 0; var_ind < num_vars - 1; var_ind++) {
-            size_t num_steps = ind_rest / num_parts[var_ind];
+    for (std::size_t cur_area = first_area; cur_area < last_area; cur_area++) {
+        std::size_t ind_rest = cur_area;
+        for (std::size_t var_ind = 0; var_ind < num_vars - 1; var_ind++) {
+            std::size_t num_steps = ind_rest / num_parts[var_ind];
             offset = static_cast<double>(num_steps) * steps[var_ind] +
                     steps[var_ind] / 2;
             vars[var_ind] = lim_integ[var_ind].first + offset;
@@ -74,17 +75,17 @@ double calc_val_areas(size_t first_area, size_t last_area, size_t num_vars,
     return res;
 }
 
-size_t get_num_areas(const std::vector<size_t>& num_parts) {
-    size_t number_areas = 1;
-    for (size_t part : num_parts) {
+std::size_t get_num_areas(const std::vector<std::size_t>& num_parts) {
+    std::size_t number_areas = 1;
+    for (std::size_t part : num_parts) {
         number_areas *= part;
     }
     return number_areas;
 }
 
-std::vector<double> get_steps(size_t num_vars, const std::vector<
+std::vector<double> get_steps(std::size_t num_vars, const std::vector<
         std::pair<double, double>>& lim_integ,
-        const std::vector<size_t>& num_parts) {
+        const std::vector<std::size_t>& num_parts) {
     std::vector<double> steps(num_vars);
     for (int i = 0; i < num_vars; i++) {
         steps[i] = (lim_integ[i].second - lim_integ[i].first) /

--- a/tasks/task_3/zakharov_a_multiple_integral_rec/multiple_integral.cpp
+++ b/tasks/task_3/zakharov_a_multiple_integral_rec/multiple_integral.cpp
@@ -1,0 +1,131 @@
+// Copyright 2023 Zakharov Artem
+#include "task_3/zakharov_a_multiple_integral_rec/multiple_integral.h"
+#include <cmath>
+#include <random>
+#include <boost/mpi/collectives.hpp>
+#include <boost/mpi/communicator.hpp>
+#include <boost/serialization/utility.hpp>
+
+double calc_integ_par(size_t num_vars, func f,
+                      const std::vector<size_t>& num_parts,
+                      std::vector<std::pair<double, double>>* lim_integ) {
+    boost::mpi::communicator comm;
+    double global_res = 0;
+
+    lim_integ->resize(num_vars);
+    boost::mpi::broadcast(comm, lim_integ->data(),
+                          static_cast<int>(num_vars), 0);
+
+    size_t num_areas = get_num_areas(num_parts);
+    size_t num_local_areas = num_areas / comm.size();
+
+    std::vector<double> steps = get_steps(num_vars, *lim_integ, num_parts);
+
+    std::vector<double> vars(num_vars);
+    size_t first_area = num_local_areas * comm.rank();
+    size_t last_area = first_area + num_local_areas;
+    if (comm.rank() == comm.size() - 1) {
+        last_area += num_areas % comm.size();
+    }
+
+    double local_res = calc_val_areas(first_area, last_area, num_vars, f,
+                                      num_parts, *lim_integ, steps);
+
+    boost::mpi::reduce(comm, local_res, global_res, std::plus(), 0);
+    global_res = calc_volume(global_res, steps);
+    return global_res;
+}
+
+double calc_integ_seq(size_t num_vars, func f,
+                      const std::vector<size_t>& num_parts,
+                      const std::vector<
+                              std::pair<double, double>>& lim_integ) {
+    size_t num_areas = get_num_areas(num_parts);
+
+    std::vector<double> steps = get_steps(num_vars, lim_integ, num_parts);
+
+    double res = calc_val_areas(0, num_areas, num_vars, f,
+                                num_parts, lim_integ, steps);
+    res = calc_volume(res, steps);
+    return res;
+}
+
+double calc_val_areas(size_t first_area, size_t last_area, size_t num_vars,
+                      func f, const std::vector<size_t>& num_parts,
+                      const std::vector<std::pair<double, double>>& lim_integ,
+                      const std::vector<double>& steps) {
+    double res = 0;
+    double offset;
+    std::vector<double> vars(num_vars);
+    for (size_t cur_area = first_area; cur_area < last_area; cur_area++) {
+        size_t ind_rest = cur_area;
+        for (size_t var_ind = 0; var_ind < num_vars - 1; var_ind++) {
+            size_t num_steps = ind_rest / num_parts[var_ind];
+            offset = static_cast<double>(num_steps) * steps[var_ind] +
+                    steps[var_ind] / 2;
+            vars[var_ind] = lim_integ[var_ind].first + offset;
+            ind_rest %= num_parts[var_ind];
+        }
+        offset = static_cast<double>(ind_rest) * steps[num_vars - 1] +
+                steps[num_vars - 1] / 2;
+        vars[num_vars - 1] = lim_integ[num_vars - 1].first + offset;
+        res += f(vars);
+    }
+    return res;
+}
+
+size_t get_num_areas(const std::vector<size_t>& num_parts) {
+    size_t number_areas = 1;
+    for (size_t part : num_parts) {
+        number_areas *= part;
+    }
+    return number_areas;
+}
+
+std::vector<double> get_steps(size_t num_vars, const std::vector<
+        std::pair<double, double>>& lim_integ,
+        const std::vector<size_t>& num_parts) {
+    std::vector<double> steps(num_vars);
+    for (int i = 0; i < num_vars; i++) {
+        steps[i] = (lim_integ[i].second - lim_integ[i].first) /
+                   static_cast<double>(num_parts[i]);
+    }
+    return steps;
+}
+
+double calc_volume(double sum_areas, const std::vector<double>& steps) {
+    for (double step : steps) {
+        sum_areas *= step;
+    }
+    return sum_areas;
+}
+
+std::pair<double, double> get_random_lim(int min_val, int max_val) {
+    std::random_device dev;
+    std::mt19937 gen(dev());
+    std::uniform_int_distribution<int> distrib1(min_val, max_val);
+    int first = distrib1(gen);
+    std::uniform_int_distribution<int>distrib2(first, max_val);
+    return {first, distrib2(gen)};
+}
+
+double one_var_func(const std::vector<double>& vars) {
+    return std::sin(vars[0]);
+}
+
+double two_var_func(const std::vector<double>& vars) {
+    return std::pow(vars[0], 2) * std::pow(vars[1], 3);
+}
+
+double two_var_func_2(const std::vector<double>& vars) {
+    return std::sin(vars[0]) + std::cos(vars[1]);
+}
+
+double three_var_func(const std::vector<double>& vars) {
+    return std::pow(std::sin(vars[1]), 2) * std::cos(vars[0]) +
+    std::sqrt(vars[2]);
+}
+
+double four_var_func(const std::vector<double>& vars) {
+    return std::pow(vars[1] + vars[2], 3) + std::cos(vars[3]) * vars[0];
+}

--- a/tasks/task_3/zakharov_a_multiple_integral_rec/multiple_integral.h
+++ b/tasks/task_3/zakharov_a_multiple_integral_rec/multiple_integral.h
@@ -1,0 +1,37 @@
+// Copyright 2023 Zakharov Artem
+#ifndef TASKS_TASK_3_ZAKHAROV_A_MULTIPLE_INTEGRAL_REC_MULTIPLE_INTEGRAL_H_
+#define TASKS_TASK_3_ZAKHAROV_A_MULTIPLE_INTEGRAL_REC_MULTIPLE_INTEGRAL_H_
+#include <vector>
+#include <utility>
+
+typedef double (*func)(const std::vector<double>&);
+
+double calc_integ_par(size_t num_vars, func f,
+                      const std::vector<size_t>& num_parts,
+                      std::vector<std::pair<double, double>>* lim_integ);
+
+double calc_integ_seq(size_t num_vars, func f,
+                      const std::vector<size_t>& num_parts,
+                      const std::vector<std::pair<double, double>>& lim_integ);
+double calc_val_areas(size_t first_area, size_t last_area, size_t num_vars,
+                      func f, const std::vector<size_t>& num_parts,
+                      const std::vector<std::pair<double, double>>& lim_integ,
+                      const std::vector<double>& steps);
+
+double calc_volume(double sum_areas, const std::vector<double>& steps);
+
+size_t get_num_areas(const std::vector<size_t>& num_parts);
+
+std::vector<double> get_steps(size_t num_vars, const std::vector<
+        std::pair<double, double>>& lim_integ,
+        const std::vector<size_t>& num_parts);
+
+std::pair<double, double> get_random_lim(int min_val, int max_val);
+
+double one_var_func(const std::vector<double>& vars);
+double two_var_func(const std::vector<double>& vars);
+double two_var_func_2(const std::vector<double>& vars);
+double three_var_func(const std::vector<double>& vars);
+double four_var_func(const std::vector<double>& vars);
+
+#endif  // TASKS_TASK_3_ZAKHAROV_A_MULTIPLE_INTEGRAL_REC_MULTIPLE_INTEGRAL_H_

--- a/tasks/task_3/zakharov_a_multiple_integral_rec/multiple_integral.h
+++ b/tasks/task_3/zakharov_a_multiple_integral_rec/multiple_integral.h
@@ -3,28 +3,30 @@
 #define TASKS_TASK_3_ZAKHAROV_A_MULTIPLE_INTEGRAL_REC_MULTIPLE_INTEGRAL_H_
 #include <vector>
 #include <utility>
+#include <cstddef>
 
 typedef double (*func)(const std::vector<double>&);
 
-double calc_integ_par(size_t num_vars, func f,
-                      const std::vector<size_t>& num_parts,
+double calc_integ_par(std::size_t num_vars, func f,
+                      const std::vector<std::size_t>& num_parts,
                       std::vector<std::pair<double, double>>* lim_integ);
 
-double calc_integ_seq(size_t num_vars, func f,
-                      const std::vector<size_t>& num_parts,
+double calc_integ_seq(std::size_t num_vars, func f,
+                      const std::vector<std::size_t>& num_parts,
                       const std::vector<std::pair<double, double>>& lim_integ);
-double calc_val_areas(size_t first_area, size_t last_area, size_t num_vars,
-                      func f, const std::vector<size_t>& num_parts,
+double calc_val_areas(std::size_t first_area, std::size_t last_area,
+                      std::size_t num_vars, func f,
+                      const std::vector<std::size_t>& num_parts,
                       const std::vector<std::pair<double, double>>& lim_integ,
                       const std::vector<double>& steps);
 
 double calc_volume(double sum_areas, const std::vector<double>& steps);
 
-size_t get_num_areas(const std::vector<size_t>& num_parts);
+std::size_t get_num_areas(const std::vector<std::size_t>& num_parts);
 
-std::vector<double> get_steps(size_t num_vars, const std::vector<
+std::vector<double> get_steps(std::size_t num_vars, const std::vector<
         std::pair<double, double>>& lim_integ,
-        const std::vector<size_t>& num_parts);
+        const std::vector<std::size_t>& num_parts);
 
 std::pair<double, double> get_random_lim(int min_val, int max_val);
 


### PR DESCRIPTION
Для вычисления **n-го** интеграла вся область интегрирования разбивается на **n-мерные** области. Далее, полученные области разделяются между процессами. Если не удается разделить области поровну, то остаток отадется последнему процессу. Каждый процесс находит значение функции в точке конкретной области и суммирует его со значениями из других областей. Затем все суммы объединяются на `root` процессе, и полученный результат умножается на длины отрезков разбиения.

Для тестирования последовательной версии использовались значения, полученные в сервисе [desmos](https://www.desmos.com/calculator/qigfpckugc?lang=ru). Чтобы время вычисления не было слишком долгим, для обычного интеграла берется погрешность `1e-3`, для двухмерного и трехмерного `1e-1`.

При тестировании параллельной версии полученное значение сверялось со значением последовательной. Здаесь берется погрешность `1e-6`.
 
 Предполагается, что пределы инегрирования есть только на `root` процессе, поэтому для их передачи всем другим процессам используется `broadcast`. Для суммирования данных со всех процессов на `root` процессе используется `reduce`.