### PR TITLE
Кулагин Александр. Задача 3. Вариант 5. Умножение разреженных матриц. Элементы типа double. Формат хранения матрицы – столбцовый (CCS).

### DIFF
--- a/tasks/task_3/kulagin_a_sparse_mul_ccs/CMakeLists.txt
+++ b/tasks/task_3/kulagin_a_sparse_mul_ccs/CMakeLists.txt
@@ -1,0 +1,38 @@
+get_filename_component(ProjectId ${CMAKE_CURRENT_SOURCE_DIR} NAME)
+enable_testing()
+
+if( USE_MPI )
+    if( UNIX )
+        set(CMAKE_C_FLAGS  "${CMAKE_CXX_FLAGS} -Wno-uninitialized")
+        set(CMAKE_CXX_FLAGS  "${CMAKE_CXX_FLAGS} -Wno-uninitialized")
+    endif( UNIX )
+
+    set(ProjectId "${ProjectId}_mpi")
+    project( ${ProjectId} )
+    message( STATUS "-- " ${ProjectId} )
+
+    file(GLOB_RECURSE ALL_SOURCE_FILES *.cpp *.h)
+
+    set(PACK_LIB "${ProjectId}_lib")
+    add_library(${PACK_LIB} STATIC ${ALL_SOURCE_FILES} )
+
+    add_executable( ${ProjectId} ${ALL_SOURCE_FILES} )
+
+    target_link_libraries(${ProjectId} ${PACK_LIB})
+    if( MPI_COMPILE_FLAGS )
+        set_target_properties( ${ProjectId} PROPERTIES COMPILE_FLAGS "${MPI_COMPILE_FLAGS}" )
+    endif( MPI_COMPILE_FLAGS )
+
+    if( MPI_LINK_FLAGS )
+        set_target_properties( ${ProjectId} PROPERTIES LINK_FLAGS "${MPI_LINK_FLAGS}" )
+    endif( MPI_LINK_FLAGS )
+    target_link_libraries( ${ProjectId} ${MPI_LIBRARIES} )
+    target_link_libraries(${ProjectId} gtest gtest_main boost_mpi)
+
+    enable_testing()
+    add_test(NAME ${ProjectId} COMMAND ${ProjectId})
+
+    CPPCHECK_AND_COUNTS_TESTS("${ProjectId}" "${ALL_SOURCE_FILES}")
+else( USE_MPI )
+    message( STATUS "-- ${ProjectId} - NOT BUILD!"  )
+endif( USE_MPI )

--- a/tasks/task_3/kulagin_a_sparse_mul_ccs/main.cpp
+++ b/tasks/task_3/kulagin_a_sparse_mul_ccs/main.cpp
@@ -1,0 +1,307 @@
+// Copyright 2023 kulagin_a
+#include <gtest/gtest.h>
+#include <mpi.h>
+#include <cstdlib>
+#include <stdexcept>
+#include "./sparse_mul_ccs.h"
+
+static const int rows_min = 10000;
+static const int rows_max = 100000;
+static const int cols_min = 10000;
+static const int cols_max = 100000;
+static const int rows_cols_min = 10000;
+static const int rows_cols_max = 100000;
+static const double value_min = -100.0;
+static const double value_max = 100.0;
+static const double sparse_density = 0.05;
+
+template<typename T>
+static inline void print_arr(const char* name, const T* arr, int size) {
+  std::cout << name << " = [";
+  if (arr != nullptr && size > 0) {
+    int i;
+    std::cout << arr[0];
+    for (i = 1; i < size; i++) {
+      std::cout << ", " << arr[i];
+    }
+  }
+  std::cout << "]\n";
+}
+
+static inline void print_props(const sparse_ccs_props& props, const bool& print_arrs = true) {
+  std::cout << "rows = " << props.rows << '\n'
+            << "cols = " << props.cols << '\n'
+            << "vals = " << props.vals << '\n';
+  if (print_arrs) {
+    print_arr<double>("vals_arr", props.vals_arr, props.vals);
+    print_arr<int>("rows_ind_arr", props.rows_ind_arr, props.vals);
+    print_arr<int>("cols_count_arr", props.cols_count_arr, props.cols + 1);
+  }
+}
+
+template<typename T>
+static inline void print_matrix(const T* arr, int rows, int cols) {
+  int i, j;
+  for (i = 0; i < rows; i++) {
+    for (j = 0; j < cols; j++) {
+      std::cout << arr[j + i * cols] << '\t';
+    }
+    std::cout << '\n';
+  }
+}
+
+static inline void test_sparse_mul() {
+  int proc_rank;
+  double res_time[2];
+  MPI_Comm_rank(MPI_COMM_WORLD, &proc_rank);
+  sparse_ccs_props props;
+  sparse_ccs m1, m2, m3, m4;
+  char matrices_created = 1;
+  if (proc_rank == 0) {
+    // int m1_rows = rand_range<int>(static_cast<double>(rows_min), static_cast<double>(rows_max));
+    // int m2_cols = rand_range<int>(static_cast<double>(cols_min), static_cast<double>(cols_max));
+    // int cols_rows = rand_range<int>(static_cast<double>(rows_cols_min), static_cast<double>(rows_cols_max));
+    int m1_rows = 1000;
+    int m2_cols = 1000;
+    int cols_rows = 1000;
+    try {
+      m1 = rand_sparse(m1_rows, cols_rows, value_min, value_max, sparse_density);
+      m2 = rand_sparse(cols_rows, m2_cols, value_min, value_max, sparse_density);
+    } catch (const std::runtime_error& e) {
+      std::cout << e.what() << '\n';
+      matrices_created = 0;
+    }
+    m1.get_props(&props);
+    print_props(props, false);
+    m2.get_props(&props);
+    print_props(props, false);
+  }
+  MPI_Bcast(&matrices_created, 1, MPI_CHAR, 0, MPI_COMM_WORLD);
+  if (!matrices_created) {
+    ADD_FAILURE();
+    return;
+  }
+  if (proc_rank == 0) {
+    res_time[0] = MPI_Wtime();
+    m3 = m1 * m2;
+    res_time[1] = MPI_Wtime();
+    m3.get_props(&props);
+    print_props(props, false);
+    std::cout << "Sequential time = " << (res_time[1] - res_time[0]) << '\n';
+  }
+  MPI_Barrier(MPI_COMM_WORLD);
+  if (proc_rank == 0) {
+    res_time[0] = MPI_Wtime();
+  }
+  m4 = parallel_mul(&m1, &m2);
+  if (proc_rank == 0) {
+    res_time[1] = MPI_Wtime();
+  }
+  if (proc_rank == 0) {
+    m4.get_props(&props);
+    print_props(props, false);
+    std::cout << "Parallel time = " << (res_time[1] - res_time[0]) << '\n';
+    EXPECT_EQ(m3, m4);
+  }
+}
+
+TEST(Sparse_Mul_MPI, test_props) {
+  double matrix[] = { 1, 0, 0, 0,
+                       0, 4, 0, 0,
+                       2, 0, 6, 0,
+                       0, 0, 0, 8,
+                       3, 5, 0, 0,
+                       0, 0, 7, 0 };
+
+  int i;
+  sparse_ccs_props props, props_real;
+  sparse_ccs sparse_matrix(matrix, 6, 4), sparse_matrix_real;
+  double real_vals_arr[] = { 1, 2, 3, 4, 5, 6, 7, 8 };
+  int real_rows_ind_arr[] = { 0, 2, 4, 1, 4, 2, 5, 3 };
+  int real_cols_count_arr[] = { 0, 3, 5, 7, 8 };
+  props_real.rows = 6;
+  props_real.cols = 4;
+  props_real.vals = 8;
+  props_real.vals_arr = real_vals_arr;
+  props_real.rows_ind_arr = real_rows_ind_arr;
+  props_real.cols_count_arr = real_cols_count_arr;
+  EXPECT_EQ(false, sparse_matrix_real == sparse_matrix);
+  sparse_matrix_real.set_matrix(&props_real, false);
+  EXPECT_EQ(sparse_matrix_real, sparse_matrix);
+}
+
+TEST(Sparse_Mul_MPI, test_example) {
+  int proc_rank;
+  MPI_Comm_rank(MPI_COMM_WORLD, &proc_rank);
+  double matrix1[] = { 10, 20, 0, 0, 0, 0,
+                    0, 30, 0, 40, 0, 0,
+                    0, 0, 50, 60, 70, 0,
+                    0, 0, 0, 0, 0, 80 };
+
+  double matrix2[] = { 1, 0, 0, 0,
+                       0, 4, 0, 0,
+                       2, 0, 6, 0,
+                       0, 0, 0, 8,
+                       3, 5, 0, 0,
+                       0, 0, 7, 0 };
+
+  double matrix3[] = { 10, 80, 0, 0,
+                       0, 120,  0, 320,
+                       310, 350, 300, 480,
+                       0, 0, 560, 0 };
+  double* matrix_new;
+  int i;
+  sparse_ccs_props props;
+  sparse_ccs sparse_matrix1(matrix1, 4, 6), sparse_matrix2(matrix2, 6, 4);
+  sparse_ccs sparse_matrix3(matrix3, 4, 4);
+  if (proc_rank == 0) {
+    sparse_matrix1.get_props(&props);
+    print_props(props);
+    sparse_matrix2.get_props(&props);
+    print_props(props);
+    sparse_matrix3.get_props(&props);
+    // print_props(props);
+  }
+  sparse_matrix1.set_non_zero(1, 3, 5.0);
+  matrix_new = sparse_matrix1.construct_matrix();
+  EXPECT_EQ(5.0, sparse_matrix1.get(1, 3));
+  EXPECT_EQ(5.0, matrix_new[9]);
+  delete[] matrix_new;
+  sparse_matrix1.set_non_zero(1, 3, 40);
+  matrix_new = sparse_matrix1.construct_matrix();
+  for (i = 0; i < 24; i++) {
+    if (matrix_new[i] != matrix1[i] && proc_rank == 0) {
+      std::cout << i << '\n';
+      EXPECT_EQ(matrix1[i], matrix_new[i]);
+    }
+  }
+  delete[] matrix_new;
+  sparse_ccs sparse_matrix5 = parallel_mul(&sparse_matrix1, &sparse_matrix2);
+  if (proc_rank == 0) {
+    sparse_ccs sparse_matrix4 = sparse_matrix1 * sparse_matrix2;
+    sparse_matrix4.get_props(&props);
+    print_props(props);
+    sparse_matrix5.get_props(&props);
+    print_props(props);
+    EXPECT_EQ(sparse_matrix3, sparse_matrix4);
+    EXPECT_EQ(sparse_matrix3, sparse_matrix5);
+  }
+}
+
+TEST(Sparse_Mul_MPI, test_transpose) {
+  int proc_rank;
+  MPI_Comm_rank(MPI_COMM_WORLD, &proc_rank);
+  int i, j;
+  double matrix1[] = { 10, 20, 0, 0, 0, 0,
+                    0, 30, 0, 40, 0, 0,
+                    0, 0, 50, 60, 70, 0,
+                    0, 0, 0, 0, 0, 80 };
+
+  double matrix2[] = { 10, 0, 0, 0,
+                        20, 30, 0, 0,
+                        0, 0, 50, 0,
+                        0, 40, 60, 0,
+                        0, 0, 70, 0,
+                        0, 0, 0, 80 };
+  sparse_ccs sparse_matrix1(matrix1, 4, 6);
+  sparse_ccs_props props;
+  sparse_ccs sparse_matrix3 = sparse_matrix1.transpose();
+  if (proc_rank == 0) {
+    sparse_matrix3.get_props(&props);
+    // print_props(props);
+  }
+  double* matrix3 = sparse_matrix3.construct_matrix();
+  for (i = 0; i < 6; i++) {
+    for (j = 0; j < 4; j++) {
+      int ind = j + i * 4;
+      if (matrix2[ind] != matrix3[ind] && proc_rank == 0) {
+        std::cout << i << ' ' << j << '\n';
+        EXPECT_EQ(matrix2[ind], matrix3[ind]);
+      }
+    }
+  }
+  delete[] matrix3;
+}
+
+TEST(Sparse_Mul_MPI, test_rand) {
+  const double from = 0.0, to = 10.0;
+  double tmp = rand_range<double>(from, to);
+  EXPECT_EQ(true, tmp >= from);
+  EXPECT_EQ(true, tmp <= to);
+}
+
+TEST(Sparse_Mul_MPI, test_sparse_rand) {
+  int proc_rank;
+  MPI_Comm_rank(MPI_COMM_WORLD, &proc_rank);
+  if (proc_rank == 0) {
+    int i;
+    const int rows = 10, cols = 10;
+    const double from = -10.0, to = 10.0, density = 0.1;
+    sparse_ccs rand_m;
+    ASSERT_NO_THROW(rand_m = rand_sparse(rows, cols, from, to, density));
+    EXPECT_EQ(true, rand_m.is_valid());
+    sparse_ccs_props props;
+    rand_m.get_props(&props);
+    // print_props(props);
+    EXPECT_EQ(cols, props.cols);
+    EXPECT_EQ(cols, props.rows);
+    EXPECT_EQ(true, props.vals > 0);
+    EXPECT_EQ(true, props.vals <= (cols * rows) * density);
+    for (i = 0; i < props.vals; i++) {
+      EXPECT_EQ(false, is_zero(props.vals_arr[i]));
+      EXPECT_EQ(true, props.vals_arr[i] >= from);
+      EXPECT_EQ(true, props.vals_arr[i] <= to);
+      EXPECT_EQ(true, props.rows_ind_arr[i] >= 0);
+      EXPECT_EQ(true, props.rows_ind_arr[i] < rows - 1);
+    }
+    EXPECT_EQ(0, props.cols_count_arr[0]);
+    EXPECT_EQ(props.vals, props.cols_count_arr[cols]);
+    for (i = 1; i < props.cols + 1; i++) {
+      EXPECT_EQ(true, props.cols_count_arr[i] >= 0);
+      EXPECT_EQ(true, props.cols_count_arr[i] <= props.vals);
+      EXPECT_EQ(true, props.cols_count_arr[i] >= props.cols_count_arr[i-1]);
+    }
+    double* m = nullptr;
+    ASSERT_NO_THROW(m = rand_m.construct_matrix());
+    if (m != nullptr) {
+      delete[] m;
+    }
+  }
+}
+
+
+TEST(Sparse_Mul_MPI, test1) {
+  test_sparse_mul();
+}
+
+TEST(Sparse_Mul_MPI, test2) {
+  test_sparse_mul();
+}
+
+TEST(Sparse_Mul_MPI, test3) {
+  test_sparse_mul();
+}
+
+TEST(Sparse_Mul_MPI, test4) {
+  test_sparse_mul();
+}
+
+TEST(Sparse_Mul_MPI, test5) {
+  test_sparse_mul();
+}
+
+int main(int argc, char** argv) {
+  int world_rank, result;
+  MPI_Init(&argc, &argv);
+  MPI_Comm_rank(MPI_COMM_WORLD, &world_rank);
+  ::testing::InitGoogleTest(&argc, argv);
+  ::testing::TestEventListeners& listeners = ::testing::UnitTest::GetInstance()->listeners();
+  if (world_rank != 0) {
+    delete listeners.Release(listeners.default_result_printer());
+  } else {
+    std::srand(std::time(nullptr));
+  }
+  result = RUN_ALL_TESTS();
+  MPI_Finalize();
+  return result;
+}

--- a/tasks/task_3/kulagin_a_sparse_mul_ccs/sparse_mul_ccs.cpp
+++ b/tasks/task_3/kulagin_a_sparse_mul_ccs/sparse_mul_ccs.cpp
@@ -1,0 +1,478 @@
+// Copyright 2023 kulagin_a
+#include "task_3/kulagin_a_sparse_mul_ccs/sparse_mul_ccs.h"
+#include <mpi.h>
+#include <limits>
+#include <cmath>
+#include <iostream>
+#include <cstring>
+#include <stdexcept>
+#include <utility>
+#include <algorithm>
+
+sparse_ccs::sparse_ccs(const sparse_ccs& sm) {
+  operator=(sm);
+}
+
+sparse_ccs::sparse_ccs(sparse_ccs&& sm) {
+  operator=(sm);
+}
+
+sparse_ccs::sparse_ccs(const double* matrix, int rows, int cols) {
+  set_matrix(matrix, rows, cols);
+}
+
+sparse_ccs::sparse_ccs(sparse_ccs_props* props, bool do_del) {
+  set_matrix(props, do_del);
+}
+
+sparse_ccs& sparse_ccs::operator=(const sparse_ccs& sm) {
+  int i;
+  clear();
+  set_do_del(true);
+  props.vals = sm.props.vals;
+  props.rows = sm.props.rows;
+  props.cols = sm.props.rows;
+  props.vals_arr = new double[props.vals];
+  props.rows_ind_arr = new int[props.vals];
+  for (i = 0; i < props.vals; i++) {
+    props.vals_arr[i] = sm.props.vals_arr[i];
+    props.rows_ind_arr[i] = sm.props.rows_ind_arr[i];
+  }
+  props.cols_count_arr = new int[props.cols + 1];
+  for (i = 0; i < props.cols + 1; i++) {
+    props.cols_count_arr[i] = sm.props.cols_count_arr[i];
+  }
+  return *this;
+}
+
+sparse_ccs& sparse_ccs::operator=(sparse_ccs&& sm) {
+  std::swap(props, sm.props);
+  std::swap(do_del, sm.do_del);
+  return *this;
+}
+
+sparse_ccs::~sparse_ccs() {
+  clear();
+}
+
+void sparse_ccs::set_matrix(const double* matrix, int rows, int cols) {
+  int i, j;
+  clear();
+  set_do_del(true);
+  props.rows = rows;
+  props.cols = cols;
+  props.vals = 0;
+  props.cols_count_arr = new int[cols + 1];
+  props.cols_count_arr[0] = 0;
+  for (j = 0; j < cols; j++) {
+    props.cols_count_arr[j + 1] = props.cols_count_arr[j];
+    for (i = 0; i < rows; i++) {
+      if (!is_zero(matrix[j + i * cols])) {
+        props.vals++;
+        props.cols_count_arr[j + 1]++;
+      }
+    }
+  }
+  if (props.vals > 0) {
+    int k = 0;
+    props.rows_ind_arr = new int[props.vals];
+    props.vals_arr = new double[props.vals];
+    for (j = 0; j < cols; j++) {
+      for (i = 0; i < rows; i++) {
+        int ind = j + i * cols;
+        if (!is_zero(matrix[ind])) {
+          props.vals_arr[k] = matrix[ind];
+          props.rows_ind_arr[k] = i;
+          k++;
+        }
+      }
+    }
+  } else {
+    clear(true);
+    std::cout << "Cannot have 0 matrix\n";
+  }
+}
+
+void sparse_ccs::set_matrix(sparse_ccs_props* props, bool do_del) {
+  clear();
+  this->props = *props;
+  set_do_del(do_del);
+}
+
+void sparse_ccs::set_do_del(bool do_del) {
+  // sometimes you don't actually need to free memory
+  this->do_del = do_del;
+}
+
+void sparse_ccs::get_props(sparse_ccs_props* props) {
+  *props = this->props;
+}
+
+double* sparse_ccs::construct_matrix(void) const {
+  // construct dense matrix
+  double* matrix = nullptr;
+  if (is_valid()) {
+    int i, matrix_sz = props.cols * props.rows;
+    int col = 0, row, col_left = props.cols_count_arr[col + 1];
+    matrix = new double[matrix_sz];
+    std::memset(matrix, 0, matrix_sz * sizeof(double));
+    for (i = 0; i < props.vals; i++) {
+      while (col_left == 0) {
+        col++;
+        col_left = props.cols_count_arr[col + 1] - props.cols_count_arr[col];
+      }
+      row = props.rows_ind_arr[i];
+      matrix[col + row * props.cols] = props.vals_arr[i];
+      col_left--;
+    }
+  }
+  return matrix;
+}
+
+int sparse_ccs::find_val_index(int i, int j) const {
+  int ind = 0, col = 0, col_left = props.cols_count_arr[1];
+  bool found = false;
+  while (col <= j) {
+    while (col_left == 0 && col <= j) {
+      col++;
+      col_left = props.cols_count_arr[col + 1] - props.cols_count_arr[col];
+    }
+    if (col == j && props.rows_ind_arr[ind] == i) {
+      found = true;
+      break;
+    }
+    ind++;
+    col_left--;
+  }
+  if (!found) {
+    ind = -1;
+  }
+  return ind;
+}
+
+double sparse_ccs::get(int i, int j) const {
+  double val = 0.0;
+  if (is_valid() && i >= 0 && j >= 0 && i < props.rows && j < props.cols) {
+    int ind = find_val_index(i, j);
+    if (ind != -1) {
+      val = props.vals_arr[ind];
+    }
+  }
+  return val;
+}
+
+int sparse_ccs::set_non_zero(int i, int j, const double& x) {
+  int ret_status = 0;
+  if (is_valid() && x != 0.0 && i >= 0 && j >= 0 && i < props.rows && j < props.cols) {
+    int ind = find_val_index(i, j);
+    if (ind != -1) {
+        props.vals_arr[ind] = x;
+    } else {
+      ret_status = -1;
+    }
+  } else {
+    ret_status = -2;
+  }
+  return ret_status;
+}
+
+void sparse_ccs::clear(bool force) {
+  props.vals = 0;
+  props.rows = 0;
+  props.cols = 0;
+  if (do_del || force) {
+    if (props.vals_arr != nullptr) {
+      delete[] props.vals_arr;
+    }
+    if (props.rows_ind_arr != nullptr) {
+      delete[] props.rows_ind_arr;
+    }
+    if (props.cols_count_arr != nullptr) {
+      delete[] props.cols_count_arr;
+    }
+  }
+  props.vals_arr = nullptr;
+  props.rows_ind_arr = nullptr;
+  props.cols_count_arr = nullptr;
+  do_del = false;
+}
+
+bool sparse_ccs::is_valid(void) const {
+  // doesn't check props.cols_count_arr to be correct
+  return
+  (props.vals > 0 && props.rows > 0 && props.cols > 0 && props.vals_arr && props.rows_ind_arr && props.cols_count_arr);
+}
+
+bool sparse_ccs::operator==(const sparse_ccs& m) const {
+  if (!is_valid() && !m.is_valid()) {
+    return true;
+  }
+  if (!is_valid() || !m.is_valid()) {
+    return false;
+  }
+  bool res = (props.vals == m.props.vals && props.cols == m.props.cols && props.rows == m.props.rows);
+  if (res) {
+    int i;
+    for (i = 0; i < props.vals; i++) {
+      res = (props.rows_ind_arr[i] == m.props.rows_ind_arr[i] && is_zero(props.vals_arr[i] - m.props.vals_arr[i]));
+      if (!res) {
+        return res;
+      }
+    }
+    for (i = 0; i < props.cols + 1; i++) {
+      res = (props.cols_count_arr[i] == m.props.cols_count_arr[i]);
+      if (!res) {
+        return res;
+      }
+    }
+  }
+  return res;
+}
+
+bool sparse_ccs::operator!=(const sparse_ccs& m) const {
+  return !operator==(m);
+}
+
+sparse_ccs sparse_ccs::operator*(const sparse_ccs& m) const {
+  if (props.cols != m.props.rows) {
+    throw std::runtime_error("A.cols != B.rows");
+  }
+  if (!is_valid()) {
+    throw std::runtime_error("A is invalid");
+  }
+  if (!m.is_valid()) {
+    throw std::runtime_error("B is invalid");
+  }
+  int i, j;
+  sparse_ccs_props res;
+  res.rows = props.rows;
+  res.cols = m.props.cols;
+  res.cols_count_arr = new int[res.cols + 1];
+  std::vector<int> temp_rows_ind_arr;
+  temp_rows_ind_arr.reserve(std::max(props.vals, m.props.vals));
+  std::vector<double> temp_vals_arr;
+  temp_vals_arr.reserve(std::max(props.vals, m.props.vals));
+  std::memset(res.cols_count_arr, 0, (res.cols + 1) * sizeof(int));
+  sparse_ccs a = transpose();
+  for (j = 0; j < res.cols; j++) {
+    for (i = 0; i < res.rows; i++) {
+      double sum = 0.0;
+      int ks = a.props.cols_count_arr[i], kf = a.props.cols_count_arr[i+1];
+      int ls = m.props.cols_count_arr[j], lf = m.props.cols_count_arr[j+1];
+      while ((ks < kf) && (ls < lf)) {
+        if (a.props.rows_ind_arr[ks] < m.props.rows_ind_arr[ls]) {
+          ks++;
+        } else if (a.props.rows_ind_arr[ks] > m.props.rows_ind_arr[ls]) {
+          ls++;
+        } else {
+          sum += a.props.vals_arr[ks] * m.props.vals_arr[ls];
+          ks++;
+          ls++;
+        }
+      }
+      if (!is_zero(sum)) {
+        res.cols_count_arr[j + 1]++;
+        temp_rows_ind_arr.push_back(i);
+        temp_vals_arr.push_back(sum);
+      }
+    }
+    res.cols_count_arr[j + 1] += res.cols_count_arr[j];
+  }
+  res.vals = temp_vals_arr.size();
+  res.rows_ind_arr = new int[res.vals];
+  res.vals_arr = new double[res.vals];
+  std::copy(temp_rows_ind_arr.begin(), temp_rows_ind_arr.end(), res.rows_ind_arr);
+  std::copy(temp_vals_arr.begin(), temp_vals_arr.end(), res.vals_arr);
+  return sparse_ccs(&res, true);
+}
+
+sparse_ccs sparse_ccs::transpose() const {
+  if (!is_valid()) {
+    throw std::runtime_error("A is invalid");
+  }
+  int i, j;
+  sparse_ccs_props res;
+  int* temp_cols_count_arr;
+  res.rows = props.cols;
+  res.cols = props.rows;
+  res.vals = props.vals;
+  temp_cols_count_arr = new int[res.cols + 2];
+  res.rows_ind_arr = new int[res.vals];
+  res.vals_arr = new double[res.vals];
+  std::memset(temp_cols_count_arr, 0, (res.cols + 2) * sizeof(int));
+  for (i = 0; i < props.vals; i++) {
+    temp_cols_count_arr[props.rows_ind_arr[i] + 2]++;
+  }
+  for (i = 2; i < res.cols + 2; i++) {
+    temp_cols_count_arr[i] += temp_cols_count_arr[i-1];
+  }
+  for (i = 0; i < props.cols; i++) {
+    for (j = props.cols_count_arr[i]; j < props.cols_count_arr[i+1]; j++) {
+      const int ind = temp_cols_count_arr[props.rows_ind_arr[j] + 1]++;
+      res.vals_arr[ind] = props.vals_arr[j];
+      res.rows_ind_arr[ind] = i;
+    }
+  }
+  res.cols_count_arr = new int[res.cols + 1];
+  std::copy(temp_cols_count_arr, temp_cols_count_arr + res.cols + 1, res.cols_count_arr);
+  delete[] temp_cols_count_arr;
+  return sparse_ccs(&res, true);
+}
+
+sparse_ccs parallel_mul(sparse_ccs* m1, sparse_ccs* m2) {
+  int proc_rank, proc_num;
+  int i, j;
+  MPI_Comm_size(MPI_COMM_WORLD, &proc_num);
+  MPI_Comm_rank(MPI_COMM_WORLD, &proc_rank);
+  if (proc_rank == 0 && m1->props.cols != m2->props.rows) {
+    throw std::runtime_error("A.cols != B.rows");
+  }
+  if (proc_rank == 0) {
+    if (!m1->is_valid()) {
+      throw std::runtime_error("A is invalid");
+    }
+    if (!m2->is_valid()) {
+      throw std::runtime_error("B is invalid");
+    }
+  }
+  sparse_ccs a;
+  sparse_ccs& m = *m2;
+  sparse_ccs_props res;
+  res.rows = m1->props.rows;
+  res.cols = m2->props.cols;
+  int rows = m1->props.rows;
+  MPI_Bcast(&rows, 1, MPI_INT, 0, MPI_COMM_WORLD);
+  MPI_Bcast(&m, sizeof(m), MPI_BYTE, 0, MPI_COMM_WORLD);
+  if (proc_rank == 0) {
+    a = m1->transpose();
+  }
+  MPI_Bcast(&a, sizeof(a), MPI_BYTE, 0, MPI_COMM_WORLD);
+  if (proc_rank != 0) {
+    a.props.vals_arr = new double[a.props.vals];
+    a.props.rows_ind_arr = new int[a.props.vals];
+    a.props.cols_count_arr = new int[a.props.cols + 1];
+
+    m.props.vals_arr = new double[m.props.vals];
+    m.props.rows_ind_arr = new int[m.props.vals];
+    m.props.cols_count_arr = nullptr;
+  }
+  MPI_Bcast(a.props.vals_arr, a.props.vals, MPI_DOUBLE, 0, MPI_COMM_WORLD);
+  MPI_Bcast(a.props.rows_ind_arr, a.props.vals, MPI_INT, 0, MPI_COMM_WORLD);
+  MPI_Bcast(m.props.vals_arr, m.props.vals, MPI_DOUBLE, 0, MPI_COMM_WORLD);
+  MPI_Bcast(m.props.rows_ind_arr, m.props.vals, MPI_INT, 0, MPI_COMM_WORLD);
+  MPI_Bcast(a.props.cols_count_arr, a.props.cols + 1, MPI_INT, 0, MPI_COMM_WORLD);
+  int delta = (m.props.cols) / proc_num;
+  int delta_left = (m.props.cols) % proc_num;
+  int cols = (proc_rank == 0) ? delta + delta_left : delta;
+  if (proc_rank == 0) {
+    for (i = 1; i < proc_num; i++) {
+      MPI_Send(m.props.cols_count_arr + delta_left + i * (delta), delta + 1, MPI_INT, i, 0, MPI_COMM_WORLD);
+    }
+  } else {
+    m.props.cols_count_arr = new int[delta + 1];
+    MPI_Recv(m.props.cols_count_arr, delta + 1, MPI_INT, 0, 0, MPI_COMM_WORLD, MPI_STATUS_IGNORE);
+  }
+  std::vector<int> temp_rows_ind_arr;
+  std::vector<double> temp_vals_arr;
+  int* temp_cols_count_arr = new int[cols + 1];
+  std::memset(temp_cols_count_arr, 0, (cols + 1) * sizeof(int));
+  for (j = 0; j < cols; j++) {
+    for (i = 0; i < rows; i++) {
+      double sum = 0.0;
+      int ks = a.props.cols_count_arr[i], kf = a.props.cols_count_arr[i+1];
+      int ls = m.props.cols_count_arr[j], lf = m.props.cols_count_arr[j+1];
+      while ((ks < kf) && (ls < lf)) {
+        if (a.props.rows_ind_arr[ks] < m.props.rows_ind_arr[ls]) {
+          ks++;
+        } else if (a.props.rows_ind_arr[ks] > m.props.rows_ind_arr[ls]) {
+          ls++;
+        } else {
+          sum += a.props.vals_arr[ks] * m.props.vals_arr[ls];
+          ks++;
+          ls++;
+        }
+      }
+      if (!is_zero(sum)) {
+        temp_cols_count_arr[j + 1]++;
+        temp_rows_ind_arr.push_back(i);
+        temp_vals_arr.push_back(sum);
+      }
+    }
+    temp_cols_count_arr[j + 1] += temp_cols_count_arr[j];
+  }
+  int temp_vals = temp_vals_arr.size();
+  a.clear();
+  int* res_vals;
+  if (proc_rank == 0) {
+    res_vals = new int[proc_num];
+  } else {
+    m.clear(true);
+  }
+  MPI_Gather(&temp_vals, 1, MPI_INT, res_vals, 1, MPI_INT, 0, MPI_COMM_WORLD);
+  if (proc_rank == 0) {
+    for (i = 0; i < proc_num; i++) {
+      res.vals += res_vals[i];
+    }
+    res.vals_arr = new double[res.vals];
+    res.rows_ind_arr = new int[res.vals];
+    res.cols_count_arr = new int[res.cols + 1];
+    std::copy(temp_vals_arr.begin(), temp_vals_arr.end(), res.vals_arr);
+    std::copy(temp_rows_ind_arr.begin(), temp_rows_ind_arr.end(), res.rows_ind_arr);
+    std::copy(temp_cols_count_arr, temp_cols_count_arr + cols + 1, res.cols_count_arr);
+    delete[] temp_cols_count_arr;
+    int offset = res_vals[0];
+    for (i = 1; i < proc_num; i++) {
+      int ind = delta_left+(delta)*i+1;
+      MPI_Recv(res.vals_arr + offset, res_vals[i], MPI_DOUBLE, i, 0, MPI_COMM_WORLD, MPI_STATUS_IGNORE);
+      MPI_Recv(res.rows_ind_arr + offset, res_vals[i], MPI_INT, i, 1, MPI_COMM_WORLD, MPI_STATUS_IGNORE);
+      MPI_Recv(res.cols_count_arr+ind, delta, MPI_INT, i, 2, MPI_COMM_WORLD, MPI_STATUS_IGNORE);
+      for (j = ind; j < ind + delta; j++) {
+        res.cols_count_arr[j] += res.cols_count_arr[ind - 1];
+      }
+      offset += res_vals[i];
+    }
+    delete[] res_vals;
+  } else {
+    MPI_Send(temp_vals_arr.data(), temp_vals, MPI_DOUBLE, 0, 0, MPI_COMM_WORLD);
+    MPI_Send(temp_rows_ind_arr.data(), temp_vals, MPI_INT, 0, 1, MPI_COMM_WORLD);
+    MPI_Send(temp_cols_count_arr+1 , delta, MPI_INT, 0, 2, MPI_COMM_WORLD);
+    delete[] temp_cols_count_arr;
+  }
+  return sparse_ccs(&res, true);
+}
+
+sparse_ccs rand_sparse(int rows, int cols, double from, double to, double density) {
+  int i;
+  sparse_ccs_props res;
+  if (is_zero(from) && is_zero(to)) {
+    throw std::runtime_error("can't generate sparse matrix with values from 0 to 0");
+  }
+  if (rows <= 0 || cols <= 0) {
+    throw std::runtime_error("invalid matrix size");
+  }
+  if (density <= 0.0 || density >= 1.0) {
+    throw std::runtime_error("invalid density");
+  }
+  res.rows = rows;
+  res.cols = cols;
+  res.vals = static_cast<double>(rows * cols) * density;
+  if (res.vals <= 0) {
+    throw std::runtime_error("invalid density: too low");
+  }
+  res.vals_arr = new double[res.vals];
+  res.rows_ind_arr = new int[res.vals];
+  res.cols_count_arr = new int[res.cols + 1];
+  for (i = 0; i < res.vals; i++) {
+    double val;
+    while (is_zero(val = rand_range<double>(from, to))) {}
+    res.vals_arr[i] = val;
+    res.rows_ind_arr[i] = rand_range<int>(0.0, static_cast<double>(rows - 1));
+  }
+  for (i = 1; i < res.cols; i++) {
+    res.cols_count_arr[i] = rand_range<int>(0.0, static_cast<double>(res.vals));
+  }
+  res.cols_count_arr[0] = 0;
+  res.cols_count_arr[res.cols] = res.vals;
+  std::sort(res.cols_count_arr + 1, res.cols_count_arr + res.cols);
+  return sparse_ccs(&res, true);
+}

--- a/tasks/task_3/kulagin_a_sparse_mul_ccs/sparse_mul_ccs.cpp
+++ b/tasks/task_3/kulagin_a_sparse_mul_ccs/sparse_mul_ccs.cpp
@@ -292,30 +292,27 @@ sparse_ccs sparse_ccs::transpose() const {
   }
   int i, j;
   sparse_ccs_props res;
-  int* temp_cols_count_arr;
   res.rows = props.cols;
   res.cols = props.rows;
   res.vals = props.vals;
-  temp_cols_count_arr = new int[res.cols + 2];
+  // that's okay if we use a bit more memory (+1 element)
+  res.cols_count_arr = new int[res.cols + 2];
   res.rows_ind_arr = new int[res.vals];
   res.vals_arr = new double[res.vals];
-  std::memset(temp_cols_count_arr, 0, (res.cols + 2) * sizeof(int));
+  std::memset(res.cols_count_arr, 0, (res.cols + 2) * sizeof(int));
   for (i = 0; i < props.vals; i++) {
-    temp_cols_count_arr[props.rows_ind_arr[i] + 2]++;
+    res.cols_count_arr[props.rows_ind_arr[i] + 2]++;
   }
   for (i = 2; i < res.cols + 2; i++) {
-    temp_cols_count_arr[i] += temp_cols_count_arr[i-1];
+    res.cols_count_arr[i] += res.cols_count_arr[i-1];
   }
   for (i = 0; i < props.cols; i++) {
     for (j = props.cols_count_arr[i]; j < props.cols_count_arr[i+1]; j++) {
-      const int ind = temp_cols_count_arr[props.rows_ind_arr[j] + 1]++;
+      const int ind = res.cols_count_arr[props.rows_ind_arr[j] + 1]++;
       res.vals_arr[ind] = props.vals_arr[j];
       res.rows_ind_arr[ind] = i;
     }
   }
-  res.cols_count_arr = new int[res.cols + 1];
-  std::copy(temp_cols_count_arr, temp_cols_count_arr + res.cols + 1, res.cols_count_arr);
-  delete[] temp_cols_count_arr;
   return sparse_ccs(&res, true);
 }
 

--- a/tasks/task_3/kulagin_a_sparse_mul_ccs/sparse_mul_ccs.h
+++ b/tasks/task_3/kulagin_a_sparse_mul_ccs/sparse_mul_ccs.h
@@ -1,0 +1,70 @@
+// Copyright 2023 kulagin_a
+#ifndef TASKS_TASK_3_KULAGIN_A_SPARSE_MUL_CCS_SPARSE_MUL_CCS_H_
+#define TASKS_TASK_3_KULAGIN_A_SPARSE_MUL_CCS_SPARSE_MUL_CCS_H_
+
+#include <iostream>
+#include <limits>
+#include <vector>
+
+// because floating point == is weird sometimes
+template<typename T>
+inline bool is_zero(const T& x) {
+  return std::abs(x) <= std::numeric_limits<T>::epsilon();
+}
+
+// generate random value in range
+template<typename T>
+static inline T rand_range(const double& from, const double& to) {
+  // because calculations with floaing points are weird sometimes
+  double a = from + std::numeric_limits<double>::epsilon();
+  double b = to - std::numeric_limits<double>::epsilon();
+  // the formula
+  return static_cast<T>(((static_cast<double>(std::rand()) / static_cast<double>(RAND_MAX)) * (b - a)) + a);
+}
+
+// struct to store sparse ccs mtrix
+struct sparse_ccs_props {
+  int rows = 0;
+  int cols = 0;
+  int vals = 0;
+  double* vals_arr = nullptr;
+  int* rows_ind_arr = nullptr;
+  int* cols_count_arr = nullptr;
+};
+
+class sparse_ccs {
+ protected:
+  sparse_ccs_props props;
+  bool do_del = false;
+  friend sparse_ccs parallel_mul(sparse_ccs* m1, sparse_ccs* m2);
+
+ public:
+  sparse_ccs() {}
+  sparse_ccs(const sparse_ccs& sm);
+  sparse_ccs(sparse_ccs&& sm);
+  sparse_ccs(const double* matrix, int rows, int cols);
+  explicit sparse_ccs(sparse_ccs_props* props, bool do_del = true);
+  sparse_ccs& operator=(const sparse_ccs& sm);
+  sparse_ccs& operator=(sparse_ccs&& sm);
+  ~sparse_ccs();
+  void set_matrix(const double* matrix, int rows, int cols);
+  void set_matrix(sparse_ccs_props* props, bool do_del = true);
+  void set_do_del(bool do_del);
+  void get_props(sparse_ccs_props* props);
+  double* construct_matrix(void) const;
+  int find_val_index(int i, int j) const;
+  double get(int i, int j) const;
+  int set_non_zero(int i, int j, const double& x);
+  void clear(bool force = false);
+  bool is_valid(void) const;
+  bool operator==(const sparse_ccs& m) const;
+  bool operator!=(const sparse_ccs& m) const;
+  sparse_ccs operator*(const sparse_ccs& m) const;
+  sparse_ccs transpose() const;
+};
+
+sparse_ccs parallel_mul(sparse_ccs* m1, sparse_ccs* m2);
+
+sparse_ccs rand_sparse(int rows, int cols, double from = -100.0, double to = 100.0, double density = 0.1);
+
+#endif  // TASKS_TASK_3_KULAGIN_A_SPARSE_MUL_CCS_SPARSE_MUL_CCS_H_


### PR DESCRIPTION
Структура хранения sparse - `sparse_ccs_props`. Класс `sparse_ccs` - то, что управляет структурой хранения. Можно создать пустой `sparse_ccs`, создать с помощью плотной матрицы или с помощью заполненного `sparse_ccs_props`. Получить `props` можно с помощью метода 'sparse_ccs::get_props'. Последовательное перемножение - перегруженный оператор `*`. Паралелльное перемножение - функция `parallel_mul`. В алгоритме, где во время цикла for неизвестен размер массива, используется `std::vector`, который после будет скопирован уже в обычный массив. `root = 0`.

Параллельная реализация. Всем процессам от `root` передаётся: транспонированная `m1` (транспонирование производится `root` целиком) полностью и `m2`, кроме m2.cols_count_arr. Каждому процессу (кроме `root`) будет распределён `m2.cols_count_arr` с размером `delta + 1` с интервалами `delta` (и смещением остатка `delta_left`), где `delta = m2.cols / proc_num`. root получит `delta + delta_left`, где `delta_left = m2.cols % proc_num` (т.е. остаток). В каждом процессе, кроме `root`, умножение будет идти по `j = 0..(delta-1)` и `i = 0..(rows-1)`. Для `root` -> `j = 0..(delta+delta_left-1)`. После умножения мы собираем количества ненулевых значений результата от каждого процесса в массив для root (и попутно получаем количество ненулевых значений конечного результата, просуммировав). Далее `root` создаёт структуру хранения конечного результата (размеры теперь известны) и собирает все результаты с других процессов по порядку, последовательно вставляя в массивы конечного результата. Чтобы сохранить определение `cols_count_arr`, мы должны при подстановке нового `cols_count_arr` просто добавить ко всем его элементам последний элемент предыдущего `cols_count_arr`. Таким образом, результат произведения разреженных матриц будет сформирован у `root`.