### PR TITLE
Кулагин Александр. Задача 2. Вариант 6. Передача от всех одному (reduce).

### DIFF
--- a/tasks/task_2/kulagin_a_my_reduce/CMakeLists.txt
+++ b/tasks/task_2/kulagin_a_my_reduce/CMakeLists.txt
@@ -1,0 +1,38 @@
+get_filename_component(ProjectId ${CMAKE_CURRENT_SOURCE_DIR} NAME)
+enable_testing()
+
+if( USE_MPI )
+    if( UNIX )
+        set(CMAKE_C_FLAGS  "${CMAKE_CXX_FLAGS} -Wno-uninitialized")
+        set(CMAKE_CXX_FLAGS  "${CMAKE_CXX_FLAGS} -Wno-uninitialized")
+    endif( UNIX )
+
+    set(ProjectId "${ProjectId}_mpi")
+    project( ${ProjectId} )
+    message( STATUS "-- " ${ProjectId} )
+
+    file(GLOB_RECURSE ALL_SOURCE_FILES *.cpp *.h)
+
+    set(PACK_LIB "${ProjectId}_lib")
+    add_library(${PACK_LIB} STATIC ${ALL_SOURCE_FILES} )
+
+    add_executable( ${ProjectId} ${ALL_SOURCE_FILES} )
+
+    target_link_libraries(${ProjectId} ${PACK_LIB})
+    if( MPI_COMPILE_FLAGS )
+        set_target_properties( ${ProjectId} PROPERTIES COMPILE_FLAGS "${MPI_COMPILE_FLAGS}" )
+    endif( MPI_COMPILE_FLAGS )
+
+    if( MPI_LINK_FLAGS )
+        set_target_properties( ${ProjectId} PROPERTIES LINK_FLAGS "${MPI_LINK_FLAGS}" )
+    endif( MPI_LINK_FLAGS )
+    target_link_libraries( ${ProjectId} ${MPI_LIBRARIES} )
+    target_link_libraries(${ProjectId} gtest gtest_main boost_mpi)
+
+    enable_testing()
+    add_test(NAME ${ProjectId} COMMAND ${ProjectId})
+
+    CPPCHECK_AND_COUNTS_TESTS("${ProjectId}" "${ALL_SOURCE_FILES}")
+else( USE_MPI )
+    message( STATUS "-- ${ProjectId} - NOT BUILD!"  )
+endif( USE_MPI )

--- a/tasks/task_2/kulagin_a_my_reduce/main.cpp
+++ b/tasks/task_2/kulagin_a_my_reduce/main.cpp
@@ -6,7 +6,7 @@
 
 typedef int vector_type;
 static const MPI_Datatype mpi_vector_type = MPI_INT;
-static const int vector_size_mul_max = 50001;
+static const int vector_size_mul = 500;
 static const vector_type vector_element_max = 100;
 static const vector_type vector_element_min = -100;
 
@@ -18,7 +18,7 @@ inline void test_vector_scalar() {
   MPI_Comm_size(MPI_COMM_WORLD, &proc_num);
   MPI_Comm_rank(MPI_COMM_WORLD, &proc_rank);
   if (proc_rank == 0) {
-    n = proc_num * (std::rand() % vector_size_mul_max + 1);
+    n = proc_num * vector_size_mul;
     a = new vector_type[n];
     b = new vector_type[n];
     sum_real = 0;

--- a/tasks/task_2/kulagin_a_my_reduce/main.cpp
+++ b/tasks/task_2/kulagin_a_my_reduce/main.cpp
@@ -1,0 +1,101 @@
+// Copyright 2023 kulagin_a
+#include <gtest/gtest.h>
+#include <mpi.h>
+#include <cstdlib>
+#include "./my_reduce.h"
+
+typedef int vector_type;
+static const MPI_Datatype mpi_vector_type = MPI_INT;
+static const int vector_size_mul_max = 50001;
+static const vector_type vector_element_max = 100;
+static const vector_type vector_element_min = -100;
+
+inline void test_vector_scalar() {
+  double res_time[2];
+  vector_type *a, *b;
+  int i, n, proc_num, proc_rank;
+  vector_type sum, sum_all, sum_real;
+  MPI_Comm_size(MPI_COMM_WORLD, &proc_num);
+  MPI_Comm_rank(MPI_COMM_WORLD, &proc_rank);
+  if (proc_rank == 0) {
+    n = proc_num * (std::rand() % vector_size_mul_max + 1);
+    a = new vector_type[n];
+    b = new vector_type[n];
+    sum_real = 0;
+    for (i = 0; i < n; i++) {
+      a[i] = std::rand() % (vector_element_max - vector_element_min + 1) + vector_element_min;
+      b[i] = std::rand() % (vector_element_max - vector_element_min + 1) + vector_element_min;
+      sum_real += a[i] * b[i];
+    }
+  }
+  MPI_Bcast(&n, 1, mpi_vector_type, 0, MPI_COMM_WORLD);
+  n = n / proc_num;
+  if (proc_rank != 0) {
+    a = new vector_type[n];
+    b = new vector_type[n];
+  }
+  MPI_Scatter(a, n, mpi_vector_type, a, n, mpi_vector_type, 0, MPI_COMM_WORLD);
+  MPI_Scatter(b, n, mpi_vector_type, b, n, mpi_vector_type, 0, MPI_COMM_WORLD);
+  sum = sum_all = 0;
+  for (i = 0; i < n; i++) {
+    sum += a[i] * b[i];
+  }
+
+  if (proc_rank == 0) {
+    res_time[0] = MPI_Wtime();
+  }
+  MPI_Reduce(&sum, &sum_all, 1, mpi_vector_type, MPI_SUM, 0, MPI_COMM_WORLD);
+  if (proc_rank == 0) {
+    res_time[1] = MPI_Wtime();
+    std::cout << "MPI_Reduce time = " << (res_time[1] - res_time[0]) << '\n';
+  }
+  if (proc_rank == 0) {
+    res_time[0] = MPI_Wtime();
+  }
+  EXPECT_EQ(MPI_SUCCESS, my_mpi_reduce(&sum, &sum_all, 1, mpi_vector_type, MPI_SUM, 0, MPI_COMM_WORLD));
+  if (proc_rank == 0) {
+    res_time[1] = MPI_Wtime();
+    std::cout << "my_mpi_reduce time = " << (res_time[1] - res_time[0]) << '\n';
+  }
+  if (proc_rank == 0) {
+    EXPECT_EQ(sum_real, sum_all);
+  }
+  delete[] a;
+  delete[] b;
+}
+
+TEST(Parallel_Operation_Reduce_MPI, test1_vector_scalar) {
+  test_vector_scalar();
+}
+
+TEST(Parallel_Operation_Reduce_MPI, test2_vector_scalar) {
+  test_vector_scalar();
+}
+
+TEST(Parallel_Operation_Reduce_MPI, test3_vector_scalar) {
+  test_vector_scalar();
+}
+
+TEST(Parallel_Operation_Reduce_MPI, test4_vector_scalar) {
+  test_vector_scalar();
+}
+
+TEST(Parallel_Operation_Reduce_MPI, test5_vector_scalar) {
+  test_vector_scalar();
+}
+
+int main(int argc, char** argv) {
+  int world_rank, result;
+  MPI_Init(&argc, &argv);
+  MPI_Comm_rank(MPI_COMM_WORLD, &world_rank);
+  ::testing::InitGoogleTest(&argc, argv);
+  ::testing::TestEventListeners& listeners = ::testing::UnitTest::GetInstance()->listeners();
+  if (world_rank != 0) {
+    delete listeners.Release(listeners.default_result_printer());
+  } else {
+    std::srand(std::time(nullptr));
+  }
+  result = RUN_ALL_TESTS();
+  MPI_Finalize();
+  return result;
+}

--- a/tasks/task_2/kulagin_a_my_reduce/main.cpp
+++ b/tasks/task_2/kulagin_a_my_reduce/main.cpp
@@ -60,6 +60,8 @@ inline void test_vector_scalar() {
     std::cout << "MPI_Reduce time = " << (res_time[1] - res_time[0]) << '\n';
     EXPECT_EQ(sum_real, sum_all);
   }
+  // make it different
+  sum_all = 0;
   if (proc_rank == 0) {
     res_time[0] = MPI_Wtime();
   }
@@ -73,6 +75,46 @@ inline void test_vector_scalar() {
   }
   delete[] a;
   delete[] b;
+}
+
+TEST(Parallel_Operation_Reduce_MPI, test_calc_tree_props) {
+  proc_tree_props props;
+  int n = 15;
+  int* path = new int[n];
+  int path_size;
+
+  calculate_tree_props(7, n, &props, path, &path_size);
+  EXPECT_EQ(-1, props.parent);
+  EXPECT_EQ(3, props.children[0]);
+  EXPECT_EQ(11, props.children[1]);
+  EXPECT_EQ(1, path_size);
+  if (path_size == 1) {
+    EXPECT_EQ(7, path[0]);
+  }
+
+  calculate_tree_props(9, n, &props, path, &path_size);
+  EXPECT_EQ(11, props.parent);
+  EXPECT_EQ(8, props.children[0]);
+  EXPECT_EQ(10, props.children[1]);
+  EXPECT_EQ(3, path_size);
+  if (path_size == 3) {
+    EXPECT_EQ(7, path[0]);
+    EXPECT_EQ(11, path[1]);
+    EXPECT_EQ(9, path[2]);
+  }
+
+  calculate_tree_props(2, n, &props, path, &path_size);
+  EXPECT_EQ(1, props.parent);
+  EXPECT_EQ(-1, props.children[0]);
+  EXPECT_EQ(-1, props.children[1]);
+  EXPECT_EQ(4, path_size);
+  if (path_size == 4) {
+    EXPECT_EQ(7, path[0]);
+    EXPECT_EQ(3, path[1]);
+    EXPECT_EQ(1, path[2]);
+    EXPECT_EQ(2, path[3]);
+  }
+  delete[] path;
 }
 
 TEST(Parallel_Operation_Reduce_MPI, test1_vector_scalar) {

--- a/tasks/task_2/kulagin_a_my_reduce/my_reduce.cpp
+++ b/tasks/task_2/kulagin_a_my_reduce/my_reduce.cpp
@@ -1,0 +1,150 @@
+// Copyright 2023 kulagin_a
+#include "task_2/kulagin_a_my_reduce/my_reduce.h"
+#include <algorithm>
+#include <iostream>
+#include <cstdlib>
+
+static const char* incorrect_op_msg = "Incorrect MPI_Op op\n";
+static const char* incorrect_type_msg = "Incorrect MPI_Datatype type\n";
+static const int reduce_tag = 0;
+
+// I hate cppcheck
+typedef long double ldouble;
+
+template<typename T>
+static inline int my_mpi_op(T* a, T* b, int count, MPI_Op op, bool print_err = true) {
+  #ifndef shortened_for_loop
+  #define shortened_for_loop(i, n) for ((i) = 0; (i) < (n); (i)++)
+  #endif
+  int i, ret_status = MPI_SUCCESS;
+  if (op == MPI_MAX) {
+    shortened_for_loop(i, count)
+      b[i] = std::max<T>(a[i], b[i]);
+  } else if (op == MPI_MIN) {
+    shortened_for_loop(i, count)
+      b[i] = std::min<T>(a[i], b[i]);
+  } else if (op == MPI_SUM) {
+    shortened_for_loop(i, count)
+      b[i] = a[i] + b[i];
+  } else if (op == MPI_PROD) {
+    shortened_for_loop(i, count)
+      b[i] = a[i] * b[i];
+  } else if (op == MPI_LAND) {
+    shortened_for_loop(i, count)
+      b[i] = a[i] && b[i];
+  } else if (op == MPI_LOR) {
+    shortened_for_loop(i, count)
+      b[i] = a[i] || b[i];
+  } else if (op == MPI_LXOR) {
+    shortened_for_loop(i, count)
+      b[i] = !a[i] != !b[i];
+  } else {
+    if (print_err) {
+      std::cout << incorrect_op_msg;
+    }
+    ret_status = MPI_ERR_OP;
+  }
+  #undef shortened_for_loop
+  return ret_status;
+}
+
+// Because BAND, BOR and BXOR are not defined in case of floats and doubles.
+template<typename T>
+static inline int my_mpi_op_int(T* a, T* b, int count, MPI_Op op) {
+  int ret_status = my_mpi_op<T>(a, b, count, op, false);
+  if (ret_status != MPI_SUCCESS) {
+    int i;
+    ret_status = MPI_SUCCESS;
+    #ifndef shortened_for_loop
+    #define shortened_for_loop(i, n) for ((i) = 0; (i) < (n); (i)++)
+    #endif
+    if (op == MPI_BAND) {
+      shortened_for_loop(i, count)
+        b[i] = a[i] & b[i];
+    } else if (op == MPI_BOR) {
+      shortened_for_loop(i, count)
+        b[i] = a[i] | b[i];
+    } else if (op == MPI_BXOR) {
+      shortened_for_loop(i, count)
+        b[i] = a[i] ^ b[i];
+    } else {
+      std::cout << incorrect_op_msg;
+      ret_status = MPI_ERR_OP;
+    }
+    #undef shortened_for_loop
+  }
+  return ret_status;
+}
+
+int my_mpi_reduce(const void* send, void* recv, int count, MPI_Datatype type, MPI_Op op, int root, MPI_Comm comm) {
+  int proc_rank, proc_num, type_sizeof, ret, flag;
+  MPI_Comm_size(comm, &proc_num);
+  MPI_Comm_rank(comm, &proc_rank);
+  MPI_Type_size(type, &type_sizeof);
+  if (root < 0 || root >= proc_num) {
+    ret = MPI_ERR_ROOT;
+    MPI_Abort(comm, ret);
+    return ret;
+  }
+  if (count <= 0) {
+    ret = MPI_ERR_COUNT;
+    MPI_Abort(comm, ret);
+    return ret;
+  }
+  if (send == nullptr || recv == nullptr) {
+    ret = MPI_ERR_BUFFER;
+    MPI_Abort(comm, ret);
+    return ret;
+  }
+  if (root == proc_rank) {
+    int i;
+    void* tmp = std::malloc(count*type_sizeof);
+    memcpy(recv, send, count*type_sizeof);
+    for (i = 0; i < proc_num; i++) {
+      if (i != root) {
+        ret = MPI_Recv(tmp, count, type, i, reduce_tag, comm, MPI_STATUS_IGNORE);
+        if (ret != MPI_SUCCESS) {
+          std::free(tmp);
+          MPI_Abort(comm, ret);
+          return ret;
+        }
+        if (type == MPI_CHAR) {
+          ret = my_mpi_op_int<char>(reinterpret_cast<char*>(tmp), reinterpret_cast<char*>(recv), count, op);
+        } else if (type == MPI_SHORT) {
+          ret = my_mpi_op_int<int16_t>(reinterpret_cast<int16_t*>(tmp), reinterpret_cast<int16_t*>(recv), count, op);
+        } else if (type == MPI_LONG) {
+          ret = my_mpi_op_int<int32_t>(reinterpret_cast<int32_t*>(tmp), reinterpret_cast<int32_t*>(recv), count, op);
+        } else if (type == MPI_INT) {
+          ret = my_mpi_op_int<int>(reinterpret_cast<int*>(tmp), reinterpret_cast<int*>(recv), count, op);
+        } else if (type == MPI_UNSIGNED_CHAR) {
+          ret = my_mpi_op_int<uint8_t>(reinterpret_cast<uint8_t*>(tmp), reinterpret_cast<uint8_t*>(recv), count, op);
+        } else if (type == MPI_UNSIGNED_SHORT) {
+          ret = my_mpi_op_int<uint16_t>(reinterpret_cast<uint16_t*>(tmp), reinterpret_cast<uint16_t*>(recv), count, op);
+        } else if (type == MPI_UNSIGNED) {
+          ret = my_mpi_op_int<unsigned>(reinterpret_cast<unsigned*>(tmp), reinterpret_cast<unsigned*>(recv), count, op);
+        } else if (type == MPI_UNSIGNED_LONG) {
+          ret = my_mpi_op_int<uint32_t>(reinterpret_cast<uint32_t*>(tmp), reinterpret_cast<uint32_t*>(recv), count, op);
+        } else if (type == MPI_FLOAT) {
+          ret = my_mpi_op<float>(reinterpret_cast<float*>(tmp), reinterpret_cast<float*>(recv), count, op);
+        } else if (type == MPI_DOUBLE) {
+          ret = my_mpi_op<double>(reinterpret_cast<double*>(tmp), reinterpret_cast<double*>(recv), count, op);
+        } else if (type == MPI_LONG_DOUBLE) {
+          ret = my_mpi_op<ldouble>(reinterpret_cast<ldouble*>(tmp), reinterpret_cast<ldouble*>(recv), count, op);
+        } else {
+          std::cout << incorrect_type_msg;
+          ret = MPI_ERR_TYPE;
+        }
+        if (ret != MPI_SUCCESS) {
+          std::free(tmp);
+          MPI_Abort(comm, ret);
+          return ret;
+        }
+      }
+    }
+    std::free(tmp);
+  } else {
+    MPI_Send(send, count, type, root, reduce_tag, comm);
+  }
+  // MPI_Barrier(comm);
+  return MPI_SUCCESS;
+}

--- a/tasks/task_2/kulagin_a_my_reduce/my_reduce.cpp
+++ b/tasks/task_2/kulagin_a_my_reduce/my_reduce.cpp
@@ -1,8 +1,8 @@
 // Copyright 2023 kulagin_a
 #include "task_2/kulagin_a_my_reduce/my_reduce.h"
 #include <algorithm>
-#include <iostream>
 #include <cstdlib>
+#include <iostream>
 
 static const char* incorrect_op_msg = "Incorrect MPI_Op op\n";
 static const char* incorrect_type_msg = "Incorrect MPI_Datatype type\n";
@@ -11,73 +11,144 @@ static const int reduce_tag = 0;
 // I hate cppcheck
 typedef long double ldouble;
 
-template<typename T>
-static inline int my_mpi_op(T* a, T* b, int count, MPI_Op op, bool print_err = true) {
-  #ifndef shortened_for_loop
-  #define shortened_for_loop(i, n) for ((i) = 0; (i) < (n); (i)++)
-  #endif
+void calculate_tree_props(int proc_rank, int proc_num, proc_tree_props* props, int* path, int* path_size) {
+  int x = 0, y = proc_num - 1, parent = -1;
+  if (path_size) {
+    *path_size = 0;
+  }
+  if (path) {
+    std::fill(path, path + proc_num, -1);
+  }
+  while (x <= y) {
+    int mid = (x + y) / 2;
+    if (path && path_size) {
+      path[(*path_size)++] = mid;
+    }
+    if (mid == proc_rank) {
+      if (props) {
+        props->parent = parent;
+        int new_y = mid - 1, new_x = mid + 1;
+        if (new_x <= y) {
+          props->children[1] = (new_x + y) / 2;
+        } else {
+          props->children[1] = -1;
+        }
+        if (x <= new_y) {
+          props->children[0] = (x + new_y) / 2;
+        } else {
+          props->children[0] = -1;
+        }
+      }
+      return;
+    } else if (mid > proc_rank) {
+      y = mid - 1;
+    } else {
+      x = mid + 1;
+    }
+    parent = mid;
+  }
+}
+
+static inline int cmp_child(const proc_tree_props& props, int child) {
+  if (child == -1) {
+    return -1;
+  } else if (props.children[0] == child) {
+    return 0;
+  } else if (props.children[1] == child) {
+    return 1;
+  } else {
+    return -1;
+  }
+}
+
+template <typename T>
+static inline int my_mpi_op(const T *a, T *b, int count, MPI_Op op, bool print_err = true) {
+#ifndef shortened_for_loop
+#define shortened_for_loop(i, n) for ((i) = 0; (i) < (n); (i)++)
+#endif
   int i, ret_status = MPI_SUCCESS;
   if (op == MPI_MAX) {
-    shortened_for_loop(i, count)
-      b[i] = std::max<T>(a[i], b[i]);
+    shortened_for_loop(i, count) b[i] = std::max<T>(a[i], b[i]);
   } else if (op == MPI_MIN) {
-    shortened_for_loop(i, count)
-      b[i] = std::min<T>(a[i], b[i]);
+    shortened_for_loop(i, count) b[i] = std::min<T>(a[i], b[i]);
   } else if (op == MPI_SUM) {
-    shortened_for_loop(i, count)
-      b[i] = a[i] + b[i];
+    shortened_for_loop(i, count) b[i] = a[i] + b[i];
   } else if (op == MPI_PROD) {
-    shortened_for_loop(i, count)
-      b[i] = a[i] * b[i];
+    shortened_for_loop(i, count) b[i] = a[i] * b[i];
   } else if (op == MPI_LAND) {
-    shortened_for_loop(i, count)
-      b[i] = a[i] && b[i];
+    shortened_for_loop(i, count) b[i] = a[i] && b[i];
   } else if (op == MPI_LOR) {
-    shortened_for_loop(i, count)
-      b[i] = a[i] || b[i];
+    shortened_for_loop(i, count) b[i] = a[i] || b[i];
   } else if (op == MPI_LXOR) {
-    shortened_for_loop(i, count)
-      b[i] = !a[i] != !b[i];
+    shortened_for_loop(i, count) b[i] = !a[i] != !b[i];
   } else {
     if (print_err) {
       std::cout << incorrect_op_msg;
     }
     ret_status = MPI_ERR_OP;
   }
-  #undef shortened_for_loop
+#undef shortened_for_loop
   return ret_status;
 }
 
 // Because BAND, BOR and BXOR are not defined in case of floats and doubles.
-template<typename T>
-static inline int my_mpi_op_int(T* a, T* b, int count, MPI_Op op) {
+template <typename T>
+static inline int my_mpi_op_int(const T *a, T *b, int count, MPI_Op op) {
   int ret_status = my_mpi_op<T>(a, b, count, op, false);
   if (ret_status != MPI_SUCCESS) {
     int i;
     ret_status = MPI_SUCCESS;
-    #ifndef shortened_for_loop
-    #define shortened_for_loop(i, n) for ((i) = 0; (i) < (n); (i)++)
-    #endif
+#ifndef shortened_for_loop
+#define shortened_for_loop(i, n) for ((i) = 0; (i) < (n); (i)++)
+#endif
     if (op == MPI_BAND) {
-      shortened_for_loop(i, count)
-        b[i] = a[i] & b[i];
+      shortened_for_loop(i, count) b[i] = a[i] & b[i];
     } else if (op == MPI_BOR) {
-      shortened_for_loop(i, count)
-        b[i] = a[i] | b[i];
+      shortened_for_loop(i, count) b[i] = a[i] | b[i];
     } else if (op == MPI_BXOR) {
-      shortened_for_loop(i, count)
-        b[i] = a[i] ^ b[i];
+      shortened_for_loop(i, count) b[i] = a[i] ^ b[i];
     } else {
       std::cout << incorrect_op_msg;
       ret_status = MPI_ERR_OP;
     }
-    #undef shortened_for_loop
+#undef shortened_for_loop
   }
   return ret_status;
 }
 
-int my_mpi_reduce(const void* send, void* recv, int count, MPI_Datatype type, MPI_Op op, int root, MPI_Comm comm) {
-  int proc_rank, proc_num, type_sizeof, ret, flag;
+static inline int my_mpi_op_prep(const void *a, void *b, int count, MPI_Datatype type, MPI_Op op) {
+  int ret;
+  if (type == MPI_CHAR) {
+    ret = my_mpi_op_int<char>(reinterpret_cast<const char *>(a), reinterpret_cast<char *>(b), count, op);
+  } else if (type == MPI_SHORT) {
+    ret = my_mpi_op_int<int16_t>(reinterpret_cast<const int16_t *>(a), reinterpret_cast<int16_t *>(b), count, op);
+  } else if (type == MPI_LONG) {
+    ret = my_mpi_op_int<int32_t>(reinterpret_cast<const int32_t *>(a), reinterpret_cast<int32_t *>(b), count, op);
+  } else if (type == MPI_INT) {
+    ret = my_mpi_op_int<int>(reinterpret_cast<const int *>(a), reinterpret_cast<int *>(b), count, op);
+  } else if (type == MPI_UNSIGNED_CHAR) {
+    ret = my_mpi_op_int<uint8_t>(reinterpret_cast<const uint8_t *>(a), reinterpret_cast<uint8_t *>(b), count, op);
+  } else if (type == MPI_UNSIGNED_SHORT) {
+    ret = my_mpi_op_int<uint16_t>(reinterpret_cast<const uint16_t *>(a), reinterpret_cast<uint16_t *>(b), count, op);
+  } else if (type == MPI_UNSIGNED) {
+    ret = my_mpi_op_int<unsigned>(reinterpret_cast<const unsigned *>(a), reinterpret_cast<unsigned *>(b), count, op);
+  } else if (type == MPI_UNSIGNED_LONG) {
+    ret = my_mpi_op_int<uint32_t>(reinterpret_cast<const uint32_t *>(a), reinterpret_cast<uint32_t *>(b), count, op);
+  } else if (type == MPI_FLOAT) {
+    ret = my_mpi_op<float>(reinterpret_cast<const float *>(a), reinterpret_cast<float *>(b), count, op);
+  } else if (type == MPI_DOUBLE) {
+    ret = my_mpi_op<double>(reinterpret_cast<const double *>(a), reinterpret_cast<double *>(b), count, op);
+  } else if (type == MPI_LONG_DOUBLE) {
+    ret = my_mpi_op<ldouble>(reinterpret_cast<const ldouble *>(a), reinterpret_cast<ldouble *>(b), count, op);
+  } else {
+    std::cout << incorrect_type_msg;
+    ret = MPI_ERR_TYPE;
+  }
+  return ret;
+}
+
+int my_mpi_reduce(const void *send, void *recv, int count, MPI_Datatype type, MPI_Op op, int root, MPI_Comm comm) {
+  int proc_rank, proc_num, type_sizeof, ret = MPI_SUCCESS, i;
   MPI_Comm_size(comm, &proc_num);
   MPI_Comm_rank(comm, &proc_rank);
   MPI_Type_size(type, &type_sizeof);
@@ -96,55 +167,58 @@ int my_mpi_reduce(const void* send, void* recv, int count, MPI_Datatype type, MP
     MPI_Abort(comm, ret);
     return ret;
   }
-  if (root == proc_rank) {
-    int i;
-    void* tmp = std::malloc(count*type_sizeof);
-    memcpy(recv, send, count*type_sizeof);
-    for (i = 0; i < proc_num; i++) {
-      if (i != root) {
-        ret = MPI_Recv(tmp, count, type, i, reduce_tag, comm, MPI_STATUS_IGNORE);
-        if (ret != MPI_SUCCESS) {
-          std::free(tmp);
-          MPI_Abort(comm, ret);
-          return ret;
-        }
-        if (type == MPI_CHAR) {
-          ret = my_mpi_op_int<char>(reinterpret_cast<char*>(tmp), reinterpret_cast<char*>(recv), count, op);
-        } else if (type == MPI_SHORT) {
-          ret = my_mpi_op_int<int16_t>(reinterpret_cast<int16_t*>(tmp), reinterpret_cast<int16_t*>(recv), count, op);
-        } else if (type == MPI_LONG) {
-          ret = my_mpi_op_int<int32_t>(reinterpret_cast<int32_t*>(tmp), reinterpret_cast<int32_t*>(recv), count, op);
-        } else if (type == MPI_INT) {
-          ret = my_mpi_op_int<int>(reinterpret_cast<int*>(tmp), reinterpret_cast<int*>(recv), count, op);
-        } else if (type == MPI_UNSIGNED_CHAR) {
-          ret = my_mpi_op_int<uint8_t>(reinterpret_cast<uint8_t*>(tmp), reinterpret_cast<uint8_t*>(recv), count, op);
-        } else if (type == MPI_UNSIGNED_SHORT) {
-          ret = my_mpi_op_int<uint16_t>(reinterpret_cast<uint16_t*>(tmp), reinterpret_cast<uint16_t*>(recv), count, op);
-        } else if (type == MPI_UNSIGNED) {
-          ret = my_mpi_op_int<unsigned>(reinterpret_cast<unsigned*>(tmp), reinterpret_cast<unsigned*>(recv), count, op);
-        } else if (type == MPI_UNSIGNED_LONG) {
-          ret = my_mpi_op_int<uint32_t>(reinterpret_cast<uint32_t*>(tmp), reinterpret_cast<uint32_t*>(recv), count, op);
-        } else if (type == MPI_FLOAT) {
-          ret = my_mpi_op<float>(reinterpret_cast<float*>(tmp), reinterpret_cast<float*>(recv), count, op);
-        } else if (type == MPI_DOUBLE) {
-          ret = my_mpi_op<double>(reinterpret_cast<double*>(tmp), reinterpret_cast<double*>(recv), count, op);
-        } else if (type == MPI_LONG_DOUBLE) {
-          ret = my_mpi_op<ldouble>(reinterpret_cast<ldouble*>(tmp), reinterpret_cast<ldouble*>(recv), count, op);
-        } else {
-          std::cout << incorrect_type_msg;
-          ret = MPI_ERR_TYPE;
-        }
-        if (ret != MPI_SUCCESS) {
-          std::free(tmp);
-          MPI_Abort(comm, ret);
-          return ret;
-        }
-      }
-    }
-    std::free(tmp);
-  } else {
-    MPI_Send(send, count, type, root, reduce_tag, comm);
+
+  proc_tree_props props;
+  int* root_path = new int[proc_num];
+  int root_path_sz;
+  calculate_tree_props(root, proc_num, &props, root_path, &root_path_sz);
+  if (proc_rank != root) {
+    calculate_tree_props(proc_rank, proc_num, &props);
   }
-  // MPI_Barrier(comm);
-  return MPI_SUCCESS;
+  void* res;
+  if (proc_rank != root) {
+    res = std::malloc(count * type_sizeof);
+  } else {
+    res = recv;
+  }
+  memcpy(res, send, count * type_sizeof);
+  int root_path_ind;
+  if (proc_rank != root) {
+    root_path_ind = std::find(root_path, root_path + root_path_sz, proc_rank) - root_path;
+  } else {
+    root_path_ind = root_path_sz - 1;
+  }
+  if (root_path_ind >= root_path_sz) {
+    root_path_ind = -1;
+  }
+  int child_root_path = cmp_child(props, (root_path_ind == -1 || proc_rank == root) ? -1 : root_path[root_path_ind+1]);
+  for (i = 0; i < 2; i++) {
+    if (props.children[i] != -1 && i != child_root_path) {
+      void* tmp = std::malloc(count * type_sizeof);
+      MPI_Recv(tmp, count, type, props.children[i], 0, comm, MPI_STATUS_IGNORE);
+      my_mpi_op_prep(tmp, res, count, type, op);
+      std::free(tmp);
+    }
+  }
+  if (root_path_ind == -1 && props.parent != -1) {
+    MPI_Send(res, count, type, props.parent, 0, comm);
+  }
+
+  if (root_path_ind != -1 && props.parent != -1) {
+    void* tmp = std::malloc(count * type_sizeof);
+    MPI_Recv(tmp, count, type, props.parent, 1, comm, MPI_STATUS_IGNORE);
+    my_mpi_op_prep(tmp, res, count, type, op);
+    std::free(tmp);
+  }
+
+  if (child_root_path != -1) {
+    MPI_Send(res, count, type, props.children[child_root_path], 1, comm);
+  }
+
+  delete[] root_path;
+  if (proc_rank != root) {
+    std::free(res);
+  }
+  MPI_Barrier(comm);
+  return ret;
 }

--- a/tasks/task_2/kulagin_a_my_reduce/my_reduce.h
+++ b/tasks/task_2/kulagin_a_my_reduce/my_reduce.h
@@ -4,6 +4,13 @@
 
 #include <mpi.h>
 
+struct proc_tree_props {
+  int parent = -1;
+  int children[2] = { -1, -1 };
+};
+
+void calculate_tree_props(int proc_rank, int proc_num, proc_tree_props* props, int* path = NULL, int* path_size = NULL);
+
 int my_mpi_reduce(const void* sendbuf, void* recvbuf, int count, MPI_Datatype type, MPI_Op op, int root, MPI_Comm comm);
 
 #endif  // TASKS_TASK_2_KULAGIN_A_MY_REDUCE_MY_REDUCE_H_

--- a/tasks/task_2/kulagin_a_my_reduce/my_reduce.h
+++ b/tasks/task_2/kulagin_a_my_reduce/my_reduce.h
@@ -1,0 +1,9 @@
+// Copyright 2023 kulagin_a
+#ifndef TASKS_TASK_2_KULAGIN_A_MY_REDUCE_MY_REDUCE_H_
+#define TASKS_TASK_2_KULAGIN_A_MY_REDUCE_MY_REDUCE_H_
+
+#include <mpi.h>
+
+int my_mpi_reduce(const void* sendbuf, void* recvbuf, int count, MPI_Datatype type, MPI_Op op, int root, MPI_Comm comm);
+
+#endif  // TASKS_TASK_2_KULAGIN_A_MY_REDUCE_MY_REDUCE_H_


### PR DESCRIPTION
Функция `my_mpi_reduce`. Определены для всех `MPI_Datatype`, которые определены явно в C++ и которые давались на лекции. Определены все операции, которые давались на лекции, кроме `MPI_MAXLOC` и `MPI_MINLOC`. Функция возвращает статус выполнения: `MPI_SUCCESS`, `MPI_ERR_ROOT`, `MPI_ERR_COUNT`, `MPI_ERR_BUFFER`, `MPI_ERR_TYPE`, `MPI_ERR_OP`. В случае не `MPI_SUCCESS`, перед возвратом вызывается `MPI_Abort`.

Дерево процессов представлено бинарным деревом поиска (`BST`). Из самого нижнего уровня данные переходят в корень дерева. При прохождении ребра с данными происходит редукция. Данные переходят по всем путям, кроме пути от корня дерева до `root`. Когда данные дойдут до корня дерева (кроме того пути), корень дерева отправляет данные до `root` (продолжая редукцию на каждом ребре). Таким образом, на `root` придёт результат.

`struct proc_tree_props` - структура, которая содержит родителя и 2 ребёнка текущего ранга процесса в `BST`. `calculate_tree_props` подсчитывает данные для этой структуры, а также записыват путь до вершины текущего ранга процесса в 'BST', если уточнить `path` и `path_size`.

`my_mpi_op` - шаблонная функция, которая подбирает операцию на основе аргумента `MPI_Op op`.
`my_mpi_op_int` - тоже самое, что и `my_mpi_op`, но для целочисленных (так, как `BAND`, `BOR`, и `BXOR` не определены для `float` и `double`).
`my_mpi_op_prep` - подбирает шаблонный параметр для `my_mpi_op` или `my_mpi_op_int` на основе аргумента `MPI_Datatype type`.