### PR TITLE
Прокофьев Кирилл. Задача 2. Вариант 9. Обобщенная передача от всех одному (gather).

### DIFF
--- a/tasks/task_2/prokofev_k_gather_realization/CMakeLists.txt
+++ b/tasks/task_2/prokofev_k_gather_realization/CMakeLists.txt
@@ -1,0 +1,38 @@
+get_filename_component(ProjectId ${CMAKE_CURRENT_SOURCE_DIR} NAME)
+enable_testing()
+
+if( USE_MPI )
+    if( UNIX )
+        set(CMAKE_C_FLAGS  "${CMAKE_CXX_FLAGS} -Wno-uninitialized")
+        set(CMAKE_CXX_FLAGS  "${CMAKE_CXX_FLAGS} -Wno-uninitialized")
+    endif( UNIX )
+
+    set(ProjectId "${ProjectId}_mpi")
+    project( ${ProjectId} )
+    message( STATUS "-- " ${ProjectId} )
+
+    file(GLOB_RECURSE ALL_SOURCE_FILES *.cpp *.h)
+
+    set(PACK_LIB "${ProjectId}_lib")
+    add_library(${PACK_LIB} STATIC ${ALL_SOURCE_FILES} )
+
+    add_executable( ${ProjectId} ${ALL_SOURCE_FILES} )
+
+    target_link_libraries(${ProjectId} ${PACK_LIB})
+    if( MPI_COMPILE_FLAGS )
+        set_target_properties( ${ProjectId} PROPERTIES COMPILE_FLAGS "${MPI_COMPILE_FLAGS}" )
+    endif( MPI_COMPILE_FLAGS )
+
+    if( MPI_LINK_FLAGS )
+        set_target_properties( ${ProjectId} PROPERTIES LINK_FLAGS "${MPI_LINK_FLAGS}" )
+    endif( MPI_LINK_FLAGS )
+    target_link_libraries( ${ProjectId} ${MPI_LIBRARIES} )
+    target_link_libraries(${ProjectId} gtest gtest_main boost_mpi)
+
+    enable_testing()
+    add_test(NAME ${ProjectId} COMMAND ${ProjectId})
+
+    CPPCHECK_AND_COUNTS_TESTS("${ProjectId}" "${ALL_SOURCE_FILES}")
+else( USE_MPI )
+    message( STATUS "-- ${ProjectId} - NOT BUILD!"  )
+endif( USE_MPI )

--- a/tasks/task_2/prokofev_k_gather_realization/gather_realization.cpp
+++ b/tasks/task_2/prokofev_k_gather_realization/gather_realization.cpp
@@ -1,0 +1,56 @@
+// Copyright 2023 Prokofev Kirill
+#include "task_2/prokofev_k_gather_realization/gather_realization.h"
+
+
+int Gather(const void* sbuf, int scount, MPI_Datatype stype, void* rbuf,
+  int rcount, MPI_Datatype rtype, int root, MPI_Comm comm) {
+    int numProc;
+    MPI_Comm_size(comm, &numProc);
+    int rankProc;
+    MPI_Comm_rank(comm, &rankProc);
+    if (!(root >= 0 && root < numProc)) return MPI_ERR_ROOT;
+    if ((scount <= 0) || (rcount <= 0) || (rcount != scount)) return MPI_ERR_COUNT;
+    if (!(stype == MPI_INT || stype == MPI_FLOAT || stype == MPI_DOUBLE))
+      return MPI_ERR_TYPE;
+    int sizeofType = 0;
+    int father = rankProc - 1;
+    int son = rankProc + 1;
+    MPI_Type_size(stype, &sizeofType);
+    size_t bytes = static_cast<size_t>(scount * sizeofType);
+    void* tmpBuf = std::malloc(bytes * (numProc - rankProc));
+    std::memcpy(tmpBuf, sbuf, bytes);
+    if (numProc == 1) {
+      std::memcpy(rbuf, tmpBuf, bytes);
+    } else {
+      if (rankProc != 0) {
+        if (son < numProc) {
+          MPI_Recv(reinterpret_cast<char*>(tmpBuf) + 1 * rcount * sizeofType, rcount * (numProc - rankProc - 1),
+            stype, son, 0, comm, MPI_STATUS_IGNORE);
+          MPI_Send(tmpBuf, scount * (numProc - rankProc), stype, father, 0, comm);
+        }
+        else {
+          MPI_Send(tmpBuf, scount, stype, father, 0, comm);
+        }
+      }
+      else {
+        MPI_Recv(reinterpret_cast<char*>(tmpBuf) + 1 * rcount * sizeofType, rcount * (numProc - rankProc - 1),
+          stype, son, 0, comm, MPI_STATUS_IGNORE);
+        if (rankProc == root) {
+          std::memcpy(rbuf, tmpBuf, bytes * (numProc - rankProc));
+        }
+        else {
+          MPI_Send(tmpBuf, scount * numProc, stype, root, 0, comm);
+        }
+      }
+      if (rankProc == root && rankProc != 0) {
+        MPI_Recv(rbuf, scount * numProc, stype, 0, 0, comm, MPI_STATUS_IGNORE);
+      }
+    }
+    free(tmpBuf);
+    return MPI_SUCCESS;
+}
+
+
+
+
+

--- a/tasks/task_2/prokofev_k_gather_realization/gather_realization.cpp
+++ b/tasks/task_2/prokofev_k_gather_realization/gather_realization.cpp
@@ -27,18 +27,15 @@ int Gather(const void* sbuf, int scount, MPI_Datatype stype, void* rbuf,
           MPI_Recv(reinterpret_cast<char*>(tmpBuf) + 1 * rcount * sizeofType, rcount * (numProc - rankProc - 1),
             stype, son, 0, comm, MPI_STATUS_IGNORE);
           MPI_Send(tmpBuf, scount * (numProc - rankProc), stype, father, 0, comm);
-        }
-        else {
+        } else {
           MPI_Send(tmpBuf, scount, stype, father, 0, comm);
         }
-      }
-      else {
+      } else {
         MPI_Recv(reinterpret_cast<char*>(tmpBuf) + 1 * rcount * sizeofType, rcount * (numProc - rankProc - 1),
           stype, son, 0, comm, MPI_STATUS_IGNORE);
         if (rankProc == root) {
           std::memcpy(rbuf, tmpBuf, bytes * (numProc - rankProc));
-        }
-        else {
+        } else {
           MPI_Send(tmpBuf, scount * numProc, stype, root, 0, comm);
         }
       }

--- a/tasks/task_2/prokofev_k_gather_realization/gather_realization.h
+++ b/tasks/task_2/prokofev_k_gather_realization/gather_realization.h
@@ -1,0 +1,11 @@
+// Copyright 2023 Prokofev Kirill
+#ifndef TASKS_TASK_2_PROKOFEV_K_GATHER_REALIZATION_GATHER_REALIZATION_H_
+#define TASKS_TASK_2_PROKOFEV_K_GATHER_REALIZATION_GATHER_REALIZATION_H_
+
+#include <mpi.h>
+#include <cstring>
+#include <cstdlib>
+
+int Gather(const void* sbuf, int scount, MPI_Datatype stype, void* rbuf, int rcount,
+  MPI_Datatype rtype, int root, MPI_Comm comm);
+#endif  // TASKS_TASK_2_PROKOFEV_K_GATHER_REALIZATION_GATHER_REALIZATION_H_

--- a/tasks/task_2/prokofev_k_gather_realization/main.cpp
+++ b/tasks/task_2/prokofev_k_gather_realization/main.cpp
@@ -1,0 +1,192 @@
+// Copyright 2023 Prokofev Kirill
+#include <gtest/gtest.h>
+#include <mpi.h>
+#include <iostream>
+#include "./gather_realization.h"
+
+TEST(Gather_Realization, Test_With_Int_Vals) {
+  MPI_Comm comm = MPI_COMM_WORLD;
+  int rankProc;
+  MPI_Comm_rank(comm, &rankProc);
+  int numProc;
+  MPI_Comm_size(comm, &numProc);
+  int rootProc = 0;
+  int n = 1000;
+  int* sendArr = new int[n];
+  int* rbuf = nullptr;
+  int* refResult = nullptr;
+  double t1, t2, t3, t4;
+  for (int i = 0; i < n; i++) {
+    sendArr[i] = rankProc + i;
+  }
+  if (rankProc == rootProc) {
+    rbuf = reinterpret_cast<int*>(malloc(numProc * n * sizeof(int)));
+    refResult = reinterpret_cast<int*>(malloc(numProc * n * sizeof(int)));
+    t1 = MPI_Wtime();
+  }
+  int returnCode = Gather(sendArr, n, MPI_INT, rbuf, n, MPI_INT, rootProc, comm);
+  if ((rankProc == rootProc) && (returnCode == MPI_SUCCESS)) {
+    t2 = MPI_Wtime();
+    t3 = MPI_Wtime();
+  }
+  MPI_Gather(sendArr, n, MPI_INT, refResult, n, MPI_INT, rootProc, comm);
+  if ((rankProc == rootProc) && (returnCode == MPI_SUCCESS)) {
+    t4 = MPI_Wtime();
+    std::cout << "MyGatherTime = " << t2 - t1 << "\t" << "OriginalGatherTime = " << t4 - t3 << std::endl;
+    for (int i = 0; i < numProc * n; i++) {
+      EXPECT_EQ(rbuf[i], refResult[i]);
+    }
+    free(rbuf);
+    free(refResult);
+  }
+}
+
+TEST(Gather_Realization, Test_With_Double_Vals) {
+  MPI_Comm comm = MPI_COMM_WORLD;
+  int rankProc;
+  MPI_Comm_rank(comm, &rankProc);
+  int numProc;
+  MPI_Comm_size(comm, &numProc);
+  int rootProc = 0;
+  int n = 1000;
+  double* sendArr = new double[n];
+  double* rbuf = nullptr;
+  double* refResult = nullptr;
+  double t1, t2, t3, t4;
+  for (int i = 0; i < n; i++) {
+    sendArr[i] = rankProc + i / 2;
+  }
+  if (rankProc == rootProc) {
+    rbuf = reinterpret_cast<double*>(malloc(numProc * n * sizeof(double)));
+    refResult = reinterpret_cast<double*>(malloc(numProc * n * sizeof(double)));
+    t1 = MPI_Wtime();
+  }
+  int returnCode = Gather(sendArr, n, MPI_DOUBLE, rbuf, n, MPI_DOUBLE, rootProc, comm);
+  if ((rankProc == rootProc) && (returnCode == MPI_SUCCESS)) {
+    t2 = MPI_Wtime();
+    t3 = MPI_Wtime();
+  }
+  MPI_Gather(sendArr, n, MPI_DOUBLE, refResult, n, MPI_DOUBLE, rootProc, comm);
+  if ((rankProc == rootProc) && (returnCode == MPI_SUCCESS)) {
+    t4 = MPI_Wtime();
+    std::cout << "MyGatherTime = " << t2 - t1 << "\t" << "OriginalGatherTime = " << t4 - t3 << std::endl;
+    for (int i = 0; i < numProc * n; i++) {
+      EXPECT_EQ(rbuf[i], refResult[i]);
+    }
+    free(rbuf);
+    free(refResult);
+  }
+}
+
+TEST(Gather_Realization, Test_With_Float_Vals) {
+  MPI_Comm comm = MPI_COMM_WORLD;
+  int rankProc;
+  MPI_Comm_rank(comm, &rankProc);
+  int numProc;
+  MPI_Comm_size(comm, &numProc);
+  int rootProc = 0;
+  int n = 1000;
+  float* sendArr = new float[n];
+  float* rbuf = nullptr;
+  float* refResult = nullptr;
+  double t1, t2, t3, t4;
+  for (int i = 0; i < n; i++) {
+    sendArr[i] = rankProc + i / 2;
+  }
+  if (rankProc == rootProc) {
+    rbuf = reinterpret_cast<float*>(malloc(numProc * n * sizeof(float)));
+    refResult = reinterpret_cast<float*>(malloc(numProc * n * sizeof(float)));
+    t1 = MPI_Wtime();
+  }
+  int returnCode = Gather(sendArr, n, MPI_FLOAT, rbuf, n, MPI_FLOAT, rootProc, comm);
+  if ((rankProc == rootProc) && (returnCode == MPI_SUCCESS)) {
+    t2 = MPI_Wtime();
+    t3 = MPI_Wtime();
+  }
+  MPI_Gather(sendArr, n, MPI_FLOAT, refResult, n, MPI_FLOAT, rootProc, comm);
+  if ((rankProc == rootProc) && (returnCode == MPI_SUCCESS)) {
+    t4 = MPI_Wtime();
+    std::cout << "MyGatherTime = " << t2 - t1 << "\t" << "OriginalGatherTime = " << t4 - t3 << std::endl;
+    for (int i = 0; i < numProc * n; i++) {
+      EXPECT_EQ(rbuf[i], refResult[i]);
+    }
+    free(rbuf);
+    free(refResult);
+  }
+}
+
+TEST(Gather_Realization, Test_Count_Error) {
+  MPI_Comm comm = MPI_COMM_WORLD;
+  int rankProc;
+  MPI_Comm_rank(comm, &rankProc);
+  int numProc;
+  MPI_Comm_size(comm, &numProc);
+  int rootProc = 0;
+  float sendArr[100];
+  float* rbuf = nullptr;
+  for (int i = 0; i < 100; i++) {
+    sendArr[i] = rankProc + i / 2;
+  }
+  if (rankProc == rootProc) {
+    rbuf = reinterpret_cast<float*>(malloc(numProc * 100 * sizeof(float)));
+  }
+  int returnCode = Gather(sendArr, 100, MPI_FLOAT, rbuf, 50, MPI_FLOAT, rootProc, comm);
+  if (rankProc == rootProc) {
+    EXPECT_EQ(MPI_ERR_COUNT, returnCode);
+    free(rbuf);
+  }
+}
+TEST(Gather_Realization, Test_Root_Error) {
+  MPI_Comm comm = MPI_COMM_WORLD;
+  int rankProc;
+  MPI_Comm_rank(comm, &rankProc);
+  int numProc;
+  MPI_Comm_size(comm, &numProc);
+  int rootProc = -5;
+  float sendArr[100];
+  float* rbuf = nullptr;
+  for (int i = 0; i < 100; i++) {
+    sendArr[i] = rankProc + i / 2;
+  }
+  if (rankProc == rootProc) {
+    rbuf = reinterpret_cast<float*>(malloc(numProc * 100 * sizeof(float)));
+  }
+  int returnCode = Gather(sendArr, 100, MPI_FLOAT, rbuf, 100, MPI_FLOAT, rootProc, comm);
+  if (rankProc == 0) {
+    EXPECT_EQ(MPI_ERR_ROOT, returnCode);
+    free(rbuf);
+  }
+}
+TEST(Gather_Realization, Test_Type_Error) {
+  MPI_Comm comm = MPI_COMM_WORLD;
+  int rankProc;
+  MPI_Comm_rank(comm, &rankProc);
+  int numProc;
+  MPI_Comm_size(comm, &numProc);
+  int rootProc = 0;
+  float sendArr[100];
+  float* rbuf = nullptr;
+  for (int i = 0; i < 100; i++) {
+    sendArr[i] = rankProc + i / 2;
+  }
+  if (rankProc == rootProc) {
+    rbuf = reinterpret_cast<float*>(malloc(numProc * 100 * sizeof(float)));
+  }
+  int returnCode = Gather(sendArr, 100, MPI_CHAR, rbuf, 100, MPI_CHAR, rootProc, comm);
+  if (rankProc == rootProc) {
+    EXPECT_EQ(MPI_ERR_TYPE, returnCode);
+    free(rbuf);
+  }
+}
+
+
+int main(int argc, char** argv) {
+  int result_code = 0;
+  ::testing::InitGoogleTest(&argc, argv);
+  ::testing::TestEventListeners& listeners = ::testing::UnitTest::GetInstance()->listeners();
+  if (MPI_Init(&argc, &argv) != MPI_SUCCESS)
+    MPI_Abort(MPI_COMM_WORLD, -1);
+  result_code = RUN_ALL_TESTS();
+  MPI_Finalize();
+  return result_code;
+}


### PR DESCRIPTION
Задача: реализовать свою функцию Gather, которая собирает данные от всех участников группы к одному участнику, и сравнить её время работы с MPI_Gather. Функция Gather принимает на вход следующие аргументы: const void* sbuf - указатель на буфер, содержащий данные, отправляемые в корневой процесс, int scount - количество элементов в буфере отправки, MPI_Datatype stype - тип данных каждого элемента в буфере, void* rbuf - указатель на буфер корневого процесса, содержащий данные, полученные от каждого процесса, int rcount - количество элементов, полученных от каждого процесса, MPI_Datatype rtype - тип данных MPI каждого элемента в буфере, int root - ранг принимающего процесса в указанном communicator, MPI_Comm comm - коммуникатор. Возвращает MPI_SUCCESS при успешном выполнении. В противном случае возвращаемое значение является кодом ошибки. В ходе сравнения функций Gather и MPI_Gather установлено,что функция MPI_Gather работает быстрее. 