### PR TITLE
Прокофьев Кирилл. Задача 3. Вариант 17. Сортировка Шелла с четно-нечетным слиянием Бэтчера.

### DIFF
--- a/tasks/task_3/prokofev_k_Shell_sort_with_Batcher_merge/CMakeLists.txt
+++ b/tasks/task_3/prokofev_k_Shell_sort_with_Batcher_merge/CMakeLists.txt
@@ -1,0 +1,38 @@
+get_filename_component(ProjectId ${CMAKE_CURRENT_SOURCE_DIR} NAME)
+enable_testing()
+
+if( USE_MPI )
+    if( UNIX )
+        set(CMAKE_C_FLAGS  "${CMAKE_CXX_FLAGS} -Wno-uninitialized")
+        set(CMAKE_CXX_FLAGS  "${CMAKE_CXX_FLAGS} -Wno-uninitialized")
+    endif( UNIX )
+
+    set(ProjectId "${ProjectId}_mpi")
+    project( ${ProjectId} )
+    message( STATUS "-- " ${ProjectId} )
+
+    file(GLOB_RECURSE ALL_SOURCE_FILES *.cpp *.h)
+
+    set(PACK_LIB "${ProjectId}_lib")
+    add_library(${PACK_LIB} STATIC ${ALL_SOURCE_FILES} )
+
+    add_executable( ${ProjectId} ${ALL_SOURCE_FILES} )
+
+    target_link_libraries(${ProjectId} ${PACK_LIB})
+    if( MPI_COMPILE_FLAGS )
+        set_target_properties( ${ProjectId} PROPERTIES COMPILE_FLAGS "${MPI_COMPILE_FLAGS}" )
+    endif( MPI_COMPILE_FLAGS )
+
+    if( MPI_LINK_FLAGS )
+        set_target_properties( ${ProjectId} PROPERTIES LINK_FLAGS "${MPI_LINK_FLAGS}" )
+    endif( MPI_LINK_FLAGS )
+    target_link_libraries( ${ProjectId} ${MPI_LIBRARIES} )
+    target_link_libraries(${ProjectId} gtest gtest_main boost_mpi)
+
+    enable_testing()
+    add_test(NAME ${ProjectId} COMMAND ${ProjectId})
+
+    CPPCHECK_AND_COUNTS_TESTS("${ProjectId}" "${ALL_SOURCE_FILES}")
+else( USE_MPI )
+    message( STATUS "-- ${ProjectId} - NOT BUILD!"  )
+endif( USE_MPI )

--- a/tasks/task_3/prokofev_k_Shell_sort_with_Batcher_merge/main.cpp
+++ b/tasks/task_3/prokofev_k_Shell_sort_with_Batcher_merge/main.cpp
@@ -1,0 +1,123 @@
+// Copyright 2023 Prokofev Kirill
+#include <gtest/gtest.h>
+#include <mpi.h>
+#include <iostream>
+#include <algorithm>
+#include "./sort_realization.h"
+
+TEST(Sort_Realization, Test_Entered_Vector) {
+  int rankProc;
+  MPI_Comm_rank(MPI_COMM_WORLD, &rankProc);
+  std::vector<int> testVect = {5, 11, 23, 2, 4, 1, 44, 3, 0, 10, 13, 7};
+  std::vector<int> refVect = testVect;
+  double t1, t2;
+  if (rankProc == 0) {
+    t1 = MPI_Wtime();
+  }
+  ShellSortParallel(testVect);
+  if (rankProc == 0) {
+    t2 = MPI_Wtime();
+    std::cout << "algorithm time : " << t2 - t1 << std::endl;
+    std::sort(refVect.begin(), refVect.end());
+    EXPECT_EQ(testVect, refVect);
+  }
+}
+
+TEST(Sort_Realization, Test_Random_Vector_1000_Elem) {
+  int rankProc;
+  MPI_Comm_rank(MPI_COMM_WORLD, &rankProc);
+  std::vector<int> testVect = GenerateRandomVector(1000);
+  std::vector<int> refVect = testVect;
+  double t1, t2;
+  if (rankProc == 0) {
+    t1 = MPI_Wtime();
+  }
+  ShellSortParallel(testVect);
+  if (rankProc == 0) {
+    t2 = MPI_Wtime();
+    std::cout << "algorithm time : " << t2 - t1 << std::endl;
+    std::sort(refVect.begin(), refVect.end());
+    EXPECT_EQ(testVect, refVect);
+  }
+}
+
+TEST(Sort_Realization, Test_Random_Vector_5000_Elem) {
+  int rankProc;
+  MPI_Comm_rank(MPI_COMM_WORLD, &rankProc);
+  std::vector<int> testVect = GenerateRandomVector(5000);
+  std::vector<int> refVect = testVect;
+  double t1, t2;
+  if (rankProc == 0) {
+    t1 = MPI_Wtime();
+  }
+  ShellSortParallel(testVect);
+  if (rankProc == 0) {
+    t2 = MPI_Wtime();
+    std::cout << "algorithm time : " << t2 - t1 << std::endl;
+    std::sort(refVect.begin(), refVect.end());
+    EXPECT_EQ(testVect, refVect);
+  }
+}
+
+TEST(Sort_Realization, Test_Random_Vector_12223_Elem) {
+  int rankProc;
+  MPI_Comm_rank(MPI_COMM_WORLD, &rankProc);
+  std::vector<int> testVect = GenerateRandomVector(12223);
+  std::vector<int> refVect = testVect;
+  double t1, t2;
+  if (rankProc == 0) {
+    t1 = MPI_Wtime();
+  }
+  ShellSortParallel(testVect);
+  if (rankProc == 0) {
+    t2 = MPI_Wtime();
+    std::cout << "algorithm time : " << t2 - t1 << std::endl;
+    std::sort(refVect.begin(), refVect.end());
+    EXPECT_EQ(testVect, refVect);
+  }
+}
+TEST(Sort_Realization, Test_Random_Vector_777_Elem) {
+  int rankProc;
+  MPI_Comm_rank(MPI_COMM_WORLD, &rankProc);
+  std::vector<int> testVect = GenerateRandomVector(777);
+  std::vector<int> refVect = testVect;
+  double t1, t2;
+  if (rankProc == 0) {
+    t1 = MPI_Wtime();
+  }
+  ShellSortParallel(testVect);
+  if (rankProc == 0) {
+    t2 = MPI_Wtime();
+    std::cout << "algorithm time : " << t2 - t1 << std::endl;
+    std::sort(refVect.begin(), refVect.end());
+    EXPECT_EQ(testVect, refVect);
+  }
+}
+TEST(Sort_Realization, Test_Random_Vector_50000_Elem) {
+  int rankProc;
+  MPI_Comm_rank(MPI_COMM_WORLD, &rankProc);
+  std::vector<int> testVect = GenerateRandomVector(50000);
+  std::vector<int> refVect = testVect;
+  double t1, t2;
+  if (rankProc == 0) {
+    t1 = MPI_Wtime();
+  }
+  ShellSortParallel(testVect);
+  if (rankProc == 0) {
+    t2 = MPI_Wtime();
+    std::cout << "algorithm time : " << t2 - t1 << std::endl;
+    std::sort(refVect.begin(), refVect.end());
+    EXPECT_EQ(testVect, refVect);
+  }
+}
+
+int main(int argc, char** argv) {
+  int result_code = 0;
+  ::testing::InitGoogleTest(&argc, argv);
+  ::testing::TestEventListeners& listeners = ::testing::UnitTest::GetInstance()->listeners();
+  if (MPI_Init(&argc, &argv) != MPI_SUCCESS)
+    MPI_Abort(MPI_COMM_WORLD, -1);
+  result_code = RUN_ALL_TESTS();
+  MPI_Finalize();
+  return result_code;
+}

--- a/tasks/task_3/prokofev_k_Shell_sort_with_Batcher_merge/main.cpp
+++ b/tasks/task_3/prokofev_k_Shell_sort_with_Batcher_merge/main.cpp
@@ -8,13 +8,13 @@
 TEST(Sort_Realization, Test_Entered_Vector) {
   int rankProc;
   MPI_Comm_rank(MPI_COMM_WORLD, &rankProc);
-  std::vector<int> testVect = {5, 11, 23, 2, 4, 1, 44, 3, 0, 10, 13, 7};
+  std::vector<int> testVect = {5, 11, 23, 2, 4, 1, 44, 3, 0, 10, 13, 7, 100};
   std::vector<int> refVect = testVect;
   double t1, t2;
   if (rankProc == 0) {
     t1 = MPI_Wtime();
   }
-  ShellSortParallel(testVect);
+  ShellSortParallel(&testVect);
   if (rankProc == 0) {
     t2 = MPI_Wtime();
     std::cout << "algorithm time : " << t2 - t1 << std::endl;
@@ -32,7 +32,7 @@ TEST(Sort_Realization, Test_Random_Vector_1000_Elem) {
   if (rankProc == 0) {
     t1 = MPI_Wtime();
   }
-  ShellSortParallel(testVect);
+  ShellSortParallel(&testVect);
   if (rankProc == 0) {
     t2 = MPI_Wtime();
     std::cout << "algorithm time : " << t2 - t1 << std::endl;
@@ -50,7 +50,7 @@ TEST(Sort_Realization, Test_Random_Vector_5000_Elem) {
   if (rankProc == 0) {
     t1 = MPI_Wtime();
   }
-  ShellSortParallel(testVect);
+  ShellSortParallel(&testVect);
   if (rankProc == 0) {
     t2 = MPI_Wtime();
     std::cout << "algorithm time : " << t2 - t1 << std::endl;
@@ -68,7 +68,7 @@ TEST(Sort_Realization, Test_Random_Vector_12223_Elem) {
   if (rankProc == 0) {
     t1 = MPI_Wtime();
   }
-  ShellSortParallel(testVect);
+  ShellSortParallel(&testVect);
   if (rankProc == 0) {
     t2 = MPI_Wtime();
     std::cout << "algorithm time : " << t2 - t1 << std::endl;
@@ -76,6 +76,7 @@ TEST(Sort_Realization, Test_Random_Vector_12223_Elem) {
     EXPECT_EQ(testVect, refVect);
   }
 }
+
 TEST(Sort_Realization, Test_Random_Vector_777_Elem) {
   int rankProc;
   MPI_Comm_rank(MPI_COMM_WORLD, &rankProc);
@@ -85,7 +86,7 @@ TEST(Sort_Realization, Test_Random_Vector_777_Elem) {
   if (rankProc == 0) {
     t1 = MPI_Wtime();
   }
-  ShellSortParallel(testVect);
+  ShellSortParallel(&testVect);
   if (rankProc == 0) {
     t2 = MPI_Wtime();
     std::cout << "algorithm time : " << t2 - t1 << std::endl;
@@ -93,6 +94,7 @@ TEST(Sort_Realization, Test_Random_Vector_777_Elem) {
     EXPECT_EQ(testVect, refVect);
   }
 }
+
 TEST(Sort_Realization, Test_Random_Vector_50000_Elem) {
   int rankProc;
   MPI_Comm_rank(MPI_COMM_WORLD, &rankProc);
@@ -102,7 +104,7 @@ TEST(Sort_Realization, Test_Random_Vector_50000_Elem) {
   if (rankProc == 0) {
     t1 = MPI_Wtime();
   }
-  ShellSortParallel(testVect);
+  ShellSortParallel(&testVect);
   if (rankProc == 0) {
     t2 = MPI_Wtime();
     std::cout << "algorithm time : " << t2 - t1 << std::endl;

--- a/tasks/task_3/prokofev_k_Shell_sort_with_Batcher_merge/sort_realization.cpp
+++ b/tasks/task_3/prokofev_k_Shell_sort_with_Batcher_merge/sort_realization.cpp
@@ -1,0 +1,103 @@
+// Copyright 2023 Prokofev Kirill
+#include "task_3/prokofev_k_Shell_sort_with_Batcher_merge/sort_realization.h"
+
+void ShellSortSeq(std::vector<int>& vec) {
+  int vecSize = vec.size();
+  int k,j,i;
+  for (k = vecSize / 2; k > 0; k /= 2) {
+    for (i = k; i < vecSize; i++) {
+      int t = vec[i];
+      for (j = i; j >= k; j -= k) {
+        if (t < vec[j - k]) {
+          vec[j] = vec[j - k];
+        } else {
+          break;
+        }
+      }
+      vec[j] = t;
+    }
+  }
+}
+std::vector<int> BatcherMerge(const std::vector<int>& vec_1, const std::vector<int>& vec_2)
+{
+  std::vector<int> resultVector(vec_1.size() + vec_2.size());
+  size_t i = 0, j = 0, k = 0;
+  while (i < vec_1.size() && j < vec_2.size()) {
+    resultVector[k++] = (vec_1[i] < vec_2[j] ? vec_1[i++] : vec_2[j++]);
+  }
+  while (i < vec_1.size()) {
+    resultVector[k++] = vec_1[i++];
+  }
+  while (j < vec_2.size()) {
+    resultVector[k++] = vec_2[j++];
+  }
+  return resultVector;
+}
+
+void ShellSortParallel(std::vector<int>& vec) {
+  int numProc;
+  MPI_Comm_size(MPI_COMM_WORLD, &numProc);
+  int rankProc;
+  MPI_Comm_rank(MPI_COMM_WORLD, &rankProc);
+  int mainVecSize = vec.size();
+  std::vector<int> preResultVector(vec.size());
+  int remainder = vec.size() % numProc;
+  int numElemInLocalVector = vec.size() / numProc;
+  std::vector<int>localVector(numElemInLocalVector);
+  MPI_Scatter(vec.data(), numElemInLocalVector, MPI_INT, localVector.data(),
+    numElemInLocalVector, MPI_INT, 0, MPI_COMM_WORLD);
+  ShellSortSeq(localVector);
+  MPI_Gather(localVector.data(), numElemInLocalVector, MPI_INT,
+    preResultVector.data(), numElemInLocalVector, MPI_INT, 0, MPI_COMM_WORLD);
+  if (rankProc == 0) {
+    std::vector<std::vector<int>> preResultVectorContainer;
+    if (remainder > 0) {
+      std::vector<int> remainderVect;
+      int k = remainder;
+      int remIndex = vec.size() - 1;
+      while (k != 0) {
+        remainderVect.push_back(vec[remIndex]);
+        remIndex--;
+        k--;
+      }
+      while (remainder != numElemInLocalVector) 
+      {
+        remainderVect.push_back(INT_MIN);
+        remainder++;
+      }
+      ShellSortSeq(remainderVect);
+      preResultVectorContainer.push_back(remainderVect);
+    }
+    for (int i = 0; i < numProc; i++) 
+    {
+      std::vector<int> tmpVect;
+      int k = numElemInLocalVector;
+      int index = i * numElemInLocalVector;
+      while (k != 0) {
+        tmpVect.push_back(preResultVector[index]);
+        index++;
+        k--;
+      }
+      preResultVectorContainer.push_back(tmpVect);
+    }
+    vec = preResultVectorContainer[0];
+    for (int i = 1; i < preResultVectorContainer.size(); i++)
+      vec = BatcherMerge(vec, preResultVectorContainer[i]);
+    if (vec.size() != mainVecSize)
+      vec.erase(std::remove(vec.begin(),
+        vec.end(), INT_MIN), vec.end());
+  }
+ }
+
+std::vector<int> GenerateRandomVector(int n)
+{
+  if (n <= 0)
+    throw "Error";
+  std::random_device dev;
+  std::mt19937 generate(dev());
+  std::vector<int> newVector(n);
+  for (int i = 0; i < n; i++){
+    newVector[i] = generate() % n;
+  }
+  return newVector;
+}

--- a/tasks/task_3/prokofev_k_Shell_sort_with_Batcher_merge/sort_realization.cpp
+++ b/tasks/task_3/prokofev_k_Shell_sort_with_Batcher_merge/sort_realization.cpp
@@ -2,6 +2,8 @@
 #include "task_3/prokofev_k_Shell_sort_with_Batcher_merge/sort_realization.h"
 #include <algorithm>
 
+const int intMin = INT_MIN;
+
 void ShellSortSeq(std::vector<int>* vec) {
   int vecSize = vec->size();
   int gap = 1;
@@ -107,9 +109,9 @@ void BatcherSort(std::vector<int>* vec) {
   }
   if (powerOfTwo != n) {
     for (int i = 0; i < powerOfTwo - n; i++)
-      vec->push_back(INT_MIN);
+      vec->push_back(intMin);
     BatcherOddEvenMerge(vec, 0, powerOfTwo, powerOfTwo);
-    vec->erase(std::remove(vec->begin(), vec->end(), INT_MIN), vec->end());
+    vec->erase(std::remove(vec->begin(), vec->end(), intMin), vec->end());
     return;
   }
   BatcherOddEvenMerge(vec, 0, powerOfTwo, powerOfTwo);

--- a/tasks/task_3/prokofev_k_Shell_sort_with_Batcher_merge/sort_realization.cpp
+++ b/tasks/task_3/prokofev_k_Shell_sort_with_Batcher_merge/sort_realization.cpp
@@ -1,6 +1,7 @@
 // Copyright 2023 Prokofev Kirill
 #include "task_3/prokofev_k_Shell_sort_with_Batcher_merge/sort_realization.h"
 #include <algorithm>
+#include <climits>
 #include <limits>
 
 const int intMin = INT_MIN;

--- a/tasks/task_3/prokofev_k_Shell_sort_with_Batcher_merge/sort_realization.cpp
+++ b/tasks/task_3/prokofev_k_Shell_sort_with_Batcher_merge/sort_realization.cpp
@@ -1,6 +1,7 @@
 // Copyright 2023 Prokofev Kirill
 #include "task_3/prokofev_k_Shell_sort_with_Batcher_merge/sort_realization.h"
 #include <algorithm>
+#include <limits>
 
 const int intMin = INT_MIN;
 

--- a/tasks/task_3/prokofev_k_Shell_sort_with_Batcher_merge/sort_realization.cpp
+++ b/tasks/task_3/prokofev_k_Shell_sort_with_Batcher_merge/sort_realization.cpp
@@ -1,102 +1,127 @@
 // Copyright 2023 Prokofev Kirill
 #include "task_3/prokofev_k_Shell_sort_with_Batcher_merge/sort_realization.h"
 
-void ShellSortSeq(std::vector<int>& vec) {
-  int vecSize = vec.size();
-  int k,j,i;
-  for (k = vecSize / 2; k > 0; k /= 2) {
-    for (i = k; i < vecSize; i++) {
-      int t = vec[i];
-      for (j = i; j >= k; j -= k) {
-        if (t < vec[j - k]) {
-          vec[j] = vec[j - k];
-        } else {
-          break;
-        }
+void ShellSortSeq(std::vector<int>* vec) {
+  int vecSize = vec->size();
+  int gap = 1;
+  while (gap < vecSize / 3) {
+    gap = 3 * gap + 1;
+  }
+  while (gap > 0) {
+    for (int i = gap; i < vecSize; ++i) {
+      int temp = (*vec)[i];
+      int j = i;
+      while (j >= gap && (*vec)[j - gap] > temp) {
+        (*vec)[j] = (*vec)[j - gap];
+        j -= gap;
       }
-      vec[j] = t;
+      (*vec)[j] = temp;
     }
+    gap /= 3;
   }
-}
-std::vector<int> BatcherMerge(const std::vector<int>& vec_1, const std::vector<int>& vec_2)
-{
-  std::vector<int> resultVector(vec_1.size() + vec_2.size());
-  size_t i = 0, j = 0, k = 0;
-  while (i < vec_1.size() && j < vec_2.size()) {
-    resultVector[k++] = (vec_1[i] < vec_2[j] ? vec_1[i++] : vec_2[j++]);
-  }
-  while (i < vec_1.size()) {
-    resultVector[k++] = vec_1[i++];
-  }
-  while (j < vec_2.size()) {
-    resultVector[k++] = vec_2[j++];
-  }
-  return resultVector;
 }
 
-void ShellSortParallel(std::vector<int>& vec) {
+void ShellSortParallel(std::vector<int>* vec) {
   int numProc;
   MPI_Comm_size(MPI_COMM_WORLD, &numProc);
   int rankProc;
   MPI_Comm_rank(MPI_COMM_WORLD, &rankProc);
-  int mainVecSize = vec.size();
-  std::vector<int> preResultVector(vec.size());
-  int remainder = vec.size() % numProc;
-  int numElemInLocalVector = vec.size() / numProc;
+  int remainder = vec->size() % numProc;
+  std::vector<int> preResultVector(vec->size() - remainder);
+  int numElemInLocalVector = vec->size() / numProc;
   std::vector<int>localVector(numElemInLocalVector);
-  MPI_Scatter(vec.data(), numElemInLocalVector, MPI_INT, localVector.data(),
+  MPI_Scatter(vec->data(), numElemInLocalVector, MPI_INT, localVector.data(),
     numElemInLocalVector, MPI_INT, 0, MPI_COMM_WORLD);
-  ShellSortSeq(localVector);
+  ShellSortSeq(&localVector);
   MPI_Gather(localVector.data(), numElemInLocalVector, MPI_INT,
     preResultVector.data(), numElemInLocalVector, MPI_INT, 0, MPI_COMM_WORLD);
   if (rankProc == 0) {
-    std::vector<std::vector<int>> preResultVectorContainer;
     if (remainder > 0) {
       std::vector<int> remainderVect;
       int k = remainder;
-      int remIndex = vec.size() - 1;
+      int remIndex = vec->size() - 1;
       while (k != 0) {
-        remainderVect.push_back(vec[remIndex]);
+        remainderVect.push_back((*vec)[remIndex]);
         remIndex--;
         k--;
       }
-      while (remainder != numElemInLocalVector) 
-      {
-        remainderVect.push_back(INT_MIN);
-        remainder++;
+      ShellSortSeq(&remainderVect);
+      for (int i = 0; i < remainderVect.size(); i++) {
+        preResultVector.push_back(remainderVect[i]);
       }
-      ShellSortSeq(remainderVect);
-      preResultVectorContainer.push_back(remainderVect);
     }
-    for (int i = 0; i < numProc; i++) 
-    {
-      std::vector<int> tmpVect;
-      int k = numElemInLocalVector;
-      int index = i * numElemInLocalVector;
-      while (k != 0) {
-        tmpVect.push_back(preResultVector[index]);
-        index++;
-        k--;
-      }
-      preResultVectorContainer.push_back(tmpVect);
-    }
-    vec = preResultVectorContainer[0];
-    for (int i = 1; i < preResultVectorContainer.size(); i++)
-      vec = BatcherMerge(vec, preResultVectorContainer[i]);
-    if (vec.size() != mainVecSize)
-      vec.erase(std::remove(vec.begin(),
-        vec.end(), INT_MIN), vec.end());
+    BatcherSort(&preResultVector);
+    *vec = preResultVector;
   }
- }
+}
 
-std::vector<int> GenerateRandomVector(int n)
-{
+void BatcherMerge(std::vector<int>* vec, int l, int m, int r) {
+  int n1 = m - l + 1;
+  int n2 = r - m;
+  std::vector<int> L(n1);
+  std::vector<int> R(n2);
+  for (int i = 0; i < n1; ++i)
+    L[i] = (*vec)[l + i];
+  for (int j = 0; j < n2; ++j)
+    R[j] = (*vec)[m + 1 + j];
+  int i = 0, j = 0, k = l;
+  while (i < n1 && j < n2) {
+    if (L[i] <= R[j]) {
+      (*vec)[k] = L[i];
+      ++i;
+    }
+    else {
+      (*vec)[k] = R[j];
+      ++j;
+    }
+    k++;
+  }
+  while (i < n1) {
+    (*vec)[k] = L[i];
+    ++i;
+    ++k;
+  }
+}
+
+void BatcherOddEvenMerge(std::vector<int>* vec, int start, int end, int dist) {
+  if (dist > 1) {
+    int mid = dist / 2;
+    BatcherOddEvenMerge(vec, start, start + mid, mid);
+    BatcherOddEvenMerge(vec, start + mid, end, mid);
+    for (int i = start; i + mid < end; ++i) {
+      if (i % dist < mid) {
+        int l = i;
+        int r = i + mid;
+        int mergeEnd = std::min(r + mid, end);
+        BatcherMerge(vec, l, r - 1, mergeEnd - 1);
+      }
+    }
+  }
+}
+
+void BatcherSort(std::vector<int>* vec) {
+  int n = vec->size();
+  int powerOfTwo = 1;
+  while (powerOfTwo < n) {
+    powerOfTwo <<= 1;
+  }
+  if (powerOfTwo != n) {
+    for (int i = 0; i < powerOfTwo - n; i++)
+      vec->push_back(INT_MIN);
+    BatcherOddEvenMerge(vec, 0, powerOfTwo, powerOfTwo);
+    vec->erase(std::remove(vec->begin(), vec->end(), INT_MIN), vec->end());
+    return;
+  }
+  BatcherOddEvenMerge(vec, 0, powerOfTwo, powerOfTwo);
+}
+
+std::vector<int> GenerateRandomVector(int n) {
   if (n <= 0)
     throw "Error";
   std::random_device dev;
   std::mt19937 generate(dev());
   std::vector<int> newVector(n);
-  for (int i = 0; i < n; i++){
+  for (int i = 0; i < n; i++) {
     newVector[i] = generate() % n;
   }
   return newVector;

--- a/tasks/task_3/prokofev_k_Shell_sort_with_Batcher_merge/sort_realization.cpp
+++ b/tasks/task_3/prokofev_k_Shell_sort_with_Batcher_merge/sort_realization.cpp
@@ -1,5 +1,6 @@
 // Copyright 2023 Prokofev Kirill
 #include "task_3/prokofev_k_Shell_sort_with_Batcher_merge/sort_realization.h"
+#include <algorithm>
 
 void ShellSortSeq(std::vector<int>* vec) {
   int vecSize = vec->size();
@@ -69,8 +70,7 @@ void BatcherMerge(std::vector<int>* vec, int l, int m, int r) {
     if (L[i] <= R[j]) {
       (*vec)[k] = L[i];
       ++i;
-    }
-    else {
+    } else {
       (*vec)[k] = R[j];
       ++j;
     }

--- a/tasks/task_3/prokofev_k_Shell_sort_with_Batcher_merge/sort_realization.h
+++ b/tasks/task_3/prokofev_k_Shell_sort_with_Batcher_merge/sort_realization.h
@@ -1,0 +1,17 @@
+// Copyright 2023 Prokofev Kirill
+#ifndef TASKS_TASK_3_PROKOFEV_K_SHELL_SORT_WITH_BATCHER_MERGE_H_
+#define TASKS_TASK_3_PROKOFEV_K_SHELL_SORT_WITH_BATCHER_MERGE_H_
+
+#include <mpi.h>
+#include <cstring>
+#include <iostream>
+#include <vector>
+#include <random>
+
+void ShellSortSeq(std::vector<int>& vec);
+std::vector<int> BatcherMerge(const std::vector<int>& vec_1,
+  const std::vector<int>& vec_2);
+void ShellSortParallel(std::vector<int>& vec);
+std::vector<int> GenerateRandomVector(int n);
+
+#endif  // TASKS_TASK_3_PROKOFEV_K_SHELL_SORT_WITH_BATCHER_MERGE_H_

--- a/tasks/task_3/prokofev_k_Shell_sort_with_Batcher_merge/sort_realization.h
+++ b/tasks/task_3/prokofev_k_Shell_sort_with_Batcher_merge/sort_realization.h
@@ -1,6 +1,6 @@
 // Copyright 2023 Prokofev Kirill
-#ifndef TASKS_TASK_3_PROKOFEV_K_SHELL_SORT_WITH_BATCHER_MERGE_H_
-#define TASKS_TASK_3_PROKOFEV_K_SHELL_SORT_WITH_BATCHER_MERGE_H_
+#ifndef TASKS_TASK_3_PROKOFEV_K_SHELL_SORT_WITH_BATCHER_MERGE_SORT_REALIZATION_H_
+#define TASKS_TASK_3_PROKOFEV_K_SHELL_SORT_WITH_BATCHER_MERGE_SORT_REALIZATION_H_
 
 #include <mpi.h>
 #include <cstring>
@@ -8,10 +8,11 @@
 #include <vector>
 #include <random>
 
-void ShellSortSeq(std::vector<int>& vec);
-std::vector<int> BatcherMerge(const std::vector<int>& vec_1,
-  const std::vector<int>& vec_2);
-void ShellSortParallel(std::vector<int>& vec);
+void ShellSortSeq(std::vector<int>* vec);
+void ShellSortParallel(std::vector<int>* vec);
+void BatcherMerge(std::vector<int>* vec, int l, int m, int r);
+void BatcherOddEvenMerge(std::vector<int>* vec, int start, int end, int dist);
+void BatcherSort(std::vector<int>* arr);
 std::vector<int> GenerateRandomVector(int n);
 
-#endif  // TASKS_TASK_3_PROKOFEV_K_SHELL_SORT_WITH_BATCHER_MERGE_H_
+#endif  // TASKS_TASK_3_PROKOFEV_K_SHELL_SORT_WITH_BATCHER_MERGE_SORT_REALIZATION_H_


### PR DESCRIPTION
Задача: Написать параллельный алгоритм сортировки Шелла с четно-нечетным слиянием Бэтчера. Разделяем вектор на подвекторы равной длины и распределяем между процессами. Каждый процесс сортирует  свой подвектор сортировкой Шелла. Далее собираем отсортированные подвекторы в один полуотсортированный вектор. Если у нас остались нераспределенные элементы собираем их в один вектор и также сортируем сортировкой Шелла в нулевом процессе и добавляем в полуотсортированный вектор. Этот вектор сортируем сортировкой Бэтчера (в нулевом процессе) и получаем полностью отсортированный вектор.