### PR TITLE
Прокофьев Кирилл. Задача 3. Вариант 17. Сортировка Шелла с четно-нечетным слиянием Бэтчера.

### DIFF
--- a/tasks/task_3/prokofev_k_Shell_sort_with_Batcher_merge/CMakeLists.txt
+++ b/tasks/task_3/prokofev_k_Shell_sort_with_Batcher_merge/CMakeLists.txt
@@ -1,0 +1,38 @@
+get_filename_component(ProjectId ${CMAKE_CURRENT_SOURCE_DIR} NAME)
+enable_testing()
+
+if( USE_MPI )
+    if( UNIX )
+        set(CMAKE_C_FLAGS  "${CMAKE_CXX_FLAGS} -Wno-uninitialized")
+        set(CMAKE_CXX_FLAGS  "${CMAKE_CXX_FLAGS} -Wno-uninitialized")
+    endif( UNIX )
+
+    set(ProjectId "${ProjectId}_mpi")
+    project( ${ProjectId} )
+    message( STATUS "-- " ${ProjectId} )
+
+    file(GLOB_RECURSE ALL_SOURCE_FILES *.cpp *.h)
+
+    set(PACK_LIB "${ProjectId}_lib")
+    add_library(${PACK_LIB} STATIC ${ALL_SOURCE_FILES} )
+
+    add_executable( ${ProjectId} ${ALL_SOURCE_FILES} )
+
+    target_link_libraries(${ProjectId} ${PACK_LIB})
+    if( MPI_COMPILE_FLAGS )
+        set_target_properties( ${ProjectId} PROPERTIES COMPILE_FLAGS "${MPI_COMPILE_FLAGS}" )
+    endif( MPI_COMPILE_FLAGS )
+
+    if( MPI_LINK_FLAGS )
+        set_target_properties( ${ProjectId} PROPERTIES LINK_FLAGS "${MPI_LINK_FLAGS}" )
+    endif( MPI_LINK_FLAGS )
+    target_link_libraries( ${ProjectId} ${MPI_LIBRARIES} )
+    target_link_libraries(${ProjectId} gtest gtest_main boost_mpi)
+
+    enable_testing()
+    add_test(NAME ${ProjectId} COMMAND ${ProjectId})
+
+    CPPCHECK_AND_COUNTS_TESTS("${ProjectId}" "${ALL_SOURCE_FILES}")
+else( USE_MPI )
+    message( STATUS "-- ${ProjectId} - NOT BUILD!"  )
+endif( USE_MPI )

--- a/tasks/task_3/prokofev_k_Shell_sort_with_Batcher_merge/main.cpp
+++ b/tasks/task_3/prokofev_k_Shell_sort_with_Batcher_merge/main.cpp
@@ -1,0 +1,125 @@
+// Copyright 2023 Prokofev Kirill
+#include <gtest/gtest.h>
+#include <mpi.h>
+#include <iostream>
+#include <algorithm>
+#include "./sort_realization.h"
+
+TEST(Sort_Realization, Test_Entered_Vector) {
+  int rankProc;
+  MPI_Comm_rank(MPI_COMM_WORLD, &rankProc);
+  std::vector<int> testVect = {5, 11, 23, 2, 4, 1, 44, 3, 0, 10, 13, 7, 100};
+  std::vector<int> refVect = testVect;
+  double t1, t2;
+  if (rankProc == 0) {
+    t1 = MPI_Wtime();
+  }
+  ShellSortParallel(&testVect);
+  if (rankProc == 0) {
+    t2 = MPI_Wtime();
+    std::cout << "algorithm time : " << t2 - t1 << std::endl;
+    std::sort(refVect.begin(), refVect.end());
+    EXPECT_EQ(testVect, refVect);
+  }
+}
+
+TEST(Sort_Realization, Test_Random_Vector_1000_Elem) {
+  int rankProc;
+  MPI_Comm_rank(MPI_COMM_WORLD, &rankProc);
+  std::vector<int> testVect = GenerateRandomVector(1000);
+  std::vector<int> refVect = testVect;
+  double t1, t2;
+  if (rankProc == 0) {
+    t1 = MPI_Wtime();
+  }
+  ShellSortParallel(&testVect);
+  if (rankProc == 0) {
+    t2 = MPI_Wtime();
+    std::cout << "algorithm time : " << t2 - t1 << std::endl;
+    std::sort(refVect.begin(), refVect.end());
+    EXPECT_EQ(testVect, refVect);
+  }
+}
+
+TEST(Sort_Realization, Test_Random_Vector_5000_Elem) {
+  int rankProc;
+  MPI_Comm_rank(MPI_COMM_WORLD, &rankProc);
+  std::vector<int> testVect = GenerateRandomVector(5000);
+  std::vector<int> refVect = testVect;
+  double t1, t2;
+  if (rankProc == 0) {
+    t1 = MPI_Wtime();
+  }
+  ShellSortParallel(&testVect);
+  if (rankProc == 0) {
+    t2 = MPI_Wtime();
+    std::cout << "algorithm time : " << t2 - t1 << std::endl;
+    std::sort(refVect.begin(), refVect.end());
+    EXPECT_EQ(testVect, refVect);
+  }
+}
+
+TEST(Sort_Realization, Test_Random_Vector_12223_Elem) {
+  int rankProc;
+  MPI_Comm_rank(MPI_COMM_WORLD, &rankProc);
+  std::vector<int> testVect = GenerateRandomVector(12223);
+  std::vector<int> refVect = testVect;
+  double t1, t2;
+  if (rankProc == 0) {
+    t1 = MPI_Wtime();
+  }
+  ShellSortParallel(&testVect);
+  if (rankProc == 0) {
+    t2 = MPI_Wtime();
+    std::cout << "algorithm time : " << t2 - t1 << std::endl;
+    std::sort(refVect.begin(), refVect.end());
+    EXPECT_EQ(testVect, refVect);
+  }
+}
+
+TEST(Sort_Realization, Test_Random_Vector_777_Elem) {
+  int rankProc;
+  MPI_Comm_rank(MPI_COMM_WORLD, &rankProc);
+  std::vector<int> testVect = GenerateRandomVector(777);
+  std::vector<int> refVect = testVect;
+  double t1, t2;
+  if (rankProc == 0) {
+    t1 = MPI_Wtime();
+  }
+  ShellSortParallel(&testVect);
+  if (rankProc == 0) {
+    t2 = MPI_Wtime();
+    std::cout << "algorithm time : " << t2 - t1 << std::endl;
+    std::sort(refVect.begin(), refVect.end());
+    EXPECT_EQ(testVect, refVect);
+  }
+}
+
+TEST(Sort_Realization, Test_Random_Vector_50000_Elem) {
+  int rankProc;
+  MPI_Comm_rank(MPI_COMM_WORLD, &rankProc);
+  std::vector<int> testVect = GenerateRandomVector(50000);
+  std::vector<int> refVect = testVect;
+  double t1, t2;
+  if (rankProc == 0) {
+    t1 = MPI_Wtime();
+  }
+  ShellSortParallel(&testVect);
+  if (rankProc == 0) {
+    t2 = MPI_Wtime();
+    std::cout << "algorithm time : " << t2 - t1 << std::endl;
+    std::sort(refVect.begin(), refVect.end());
+    EXPECT_EQ(testVect, refVect);
+  }
+}
+
+int main(int argc, char** argv) {
+  int result_code = 0;
+  ::testing::InitGoogleTest(&argc, argv);
+  ::testing::TestEventListeners& listeners = ::testing::UnitTest::GetInstance()->listeners();
+  if (MPI_Init(&argc, &argv) != MPI_SUCCESS)
+    MPI_Abort(MPI_COMM_WORLD, -1);
+  result_code = RUN_ALL_TESTS();
+  MPI_Finalize();
+  return result_code;
+}

--- a/tasks/task_3/prokofev_k_Shell_sort_with_Batcher_merge/sort_realization.cpp
+++ b/tasks/task_3/prokofev_k_Shell_sort_with_Batcher_merge/sort_realization.cpp
@@ -1,0 +1,132 @@
+// Copyright 2023 Prokofev Kirill
+#include "task_3/prokofev_k_Shell_sort_with_Batcher_merge/sort_realization.h"
+#include <algorithm>
+#include <climits>
+#include <limits>
+
+const int intMin = INT_MIN;
+
+void ShellSortSeq(std::vector<int>* vec) {
+  int vecSize = vec->size();
+  int gap = 1;
+  while (gap < vecSize / 3) {
+    gap = 3 * gap + 1;
+  }
+  while (gap > 0) {
+    for (int i = gap; i < vecSize; ++i) {
+      int temp = (*vec)[i];
+      int j = i;
+      while (j >= gap && (*vec)[j - gap] > temp) {
+        (*vec)[j] = (*vec)[j - gap];
+        j -= gap;
+      }
+      (*vec)[j] = temp;
+    }
+    gap /= 3;
+  }
+}
+
+void ShellSortParallel(std::vector<int>* vec) {
+  int numProc;
+  MPI_Comm_size(MPI_COMM_WORLD, &numProc);
+  int rankProc;
+  MPI_Comm_rank(MPI_COMM_WORLD, &rankProc);
+  int remainder = vec->size() % numProc;
+  std::vector<int> preResultVector(vec->size() - remainder);
+  int numElemInLocalVector = vec->size() / numProc;
+  std::vector<int>localVector(numElemInLocalVector);
+  MPI_Scatter(vec->data(), numElemInLocalVector, MPI_INT, localVector.data(),
+    numElemInLocalVector, MPI_INT, 0, MPI_COMM_WORLD);
+  ShellSortSeq(&localVector);
+  MPI_Gather(localVector.data(), numElemInLocalVector, MPI_INT,
+    preResultVector.data(), numElemInLocalVector, MPI_INT, 0, MPI_COMM_WORLD);
+  if (rankProc == 0) {
+    if (remainder > 0) {
+      std::vector<int> remainderVect;
+      int k = remainder;
+      int remIndex = vec->size() - 1;
+      while (k != 0) {
+        remainderVect.push_back((*vec)[remIndex]);
+        remIndex--;
+        k--;
+      }
+      ShellSortSeq(&remainderVect);
+      for (int i = 0; i < remainderVect.size(); i++) {
+        preResultVector.push_back(remainderVect[i]);
+      }
+    }
+    BatcherSort(&preResultVector);
+    *vec = preResultVector;
+  }
+}
+
+void BatcherMerge(std::vector<int>* vec, int l, int m, int r) {
+  int n1 = m - l + 1;
+  int n2 = r - m;
+  std::vector<int> L(n1);
+  std::vector<int> R(n2);
+  for (int i = 0; i < n1; ++i)
+    L[i] = (*vec)[l + i];
+  for (int j = 0; j < n2; ++j)
+    R[j] = (*vec)[m + 1 + j];
+  int i = 0, j = 0, k = l;
+  while (i < n1 && j < n2) {
+    if (L[i] <= R[j]) {
+      (*vec)[k] = L[i];
+      ++i;
+    } else {
+      (*vec)[k] = R[j];
+      ++j;
+    }
+    k++;
+  }
+  while (i < n1) {
+    (*vec)[k] = L[i];
+    ++i;
+    ++k;
+  }
+}
+
+void BatcherOddEvenMerge(std::vector<int>* vec, int start, int end, int dist) {
+  if (dist > 1) {
+    int mid = dist / 2;
+    BatcherOddEvenMerge(vec, start, start + mid, mid);
+    BatcherOddEvenMerge(vec, start + mid, end, mid);
+    for (int i = start; i + mid < end; ++i) {
+      if (i % dist < mid) {
+        int l = i;
+        int r = i + mid;
+        int mergeEnd = std::min(r + mid, end);
+        BatcherMerge(vec, l, r - 1, mergeEnd - 1);
+      }
+    }
+  }
+}
+
+void BatcherSort(std::vector<int>* vec) {
+  int n = vec->size();
+  int powerOfTwo = 1;
+  while (powerOfTwo < n) {
+    powerOfTwo <<= 1;
+  }
+  if (powerOfTwo != n) {
+    for (int i = 0; i < powerOfTwo - n; i++)
+      vec->push_back(intMin);
+    BatcherOddEvenMerge(vec, 0, powerOfTwo, powerOfTwo);
+    vec->erase(std::remove(vec->begin(), vec->end(), intMin), vec->end());
+    return;
+  }
+  BatcherOddEvenMerge(vec, 0, powerOfTwo, powerOfTwo);
+}
+
+std::vector<int> GenerateRandomVector(int n) {
+  if (n <= 0)
+    throw "Error";
+  std::random_device dev;
+  std::mt19937 generate(dev());
+  std::vector<int> newVector(n);
+  for (int i = 0; i < n; i++) {
+    newVector[i] = generate() % n;
+  }
+  return newVector;
+}

--- a/tasks/task_3/prokofev_k_Shell_sort_with_Batcher_merge/sort_realization.h
+++ b/tasks/task_3/prokofev_k_Shell_sort_with_Batcher_merge/sort_realization.h
@@ -1,0 +1,18 @@
+// Copyright 2023 Prokofev Kirill
+#ifndef TASKS_TASK_3_PROKOFEV_K_SHELL_SORT_WITH_BATCHER_MERGE_SORT_REALIZATION_H_
+#define TASKS_TASK_3_PROKOFEV_K_SHELL_SORT_WITH_BATCHER_MERGE_SORT_REALIZATION_H_
+
+#include <mpi.h>
+#include <cstring>
+#include <iostream>
+#include <vector>
+#include <random>
+
+void ShellSortSeq(std::vector<int>* vec);
+void ShellSortParallel(std::vector<int>* vec);
+void BatcherMerge(std::vector<int>* vec, int l, int m, int r);
+void BatcherOddEvenMerge(std::vector<int>* vec, int start, int end, int dist);
+void BatcherSort(std::vector<int>* arr);
+std::vector<int> GenerateRandomVector(int n);
+
+#endif  // TASKS_TASK_3_PROKOFEV_K_SHELL_SORT_WITH_BATCHER_MERGE_SORT_REALIZATION_H_


### PR DESCRIPTION
Задача: Написать параллельный алгоритм сортировки Шелла с четно-нечетным слиянием Бэтчера. Разделяем вектор на подвекторы равной длины и распределяем между процессами. Каждый процесс сортирует свой подвектор сортировкой Шелла. Далее собираем отсортированные подвекторы в один полуотсортированный вектор. Если у нас остались нераспределенные элементы собираем их в один вектор и также сортируем сортировкой Шелла в нулевом процессе и добавляем в полуотсортированный вектор. Этот вектор сортируем сортировкой Бэтчера (в нулевом процессе) и получаем полностью отсортированный вектор.