### PR TITLE
Костанян Арсен. Задача 3. Вариант 21. Поразрядная сортировка для вещественных чисел (тип double)  с четно-нечетным слиянием Бэтчера.

### DIFF
--- a/tasks/task_3/kostanyan_a_radix_sort_batcher/CMakeLists.txt
+++ b/tasks/task_3/kostanyan_a_radix_sort_batcher/CMakeLists.txt
@@ -1,0 +1,38 @@
+get_filename_component(ProjectId ${CMAKE_CURRENT_SOURCE_DIR} NAME)
+enable_testing()
+
+if( USE_MPI )
+    if( UNIX )
+        set(CMAKE_C_FLAGS  "${CMAKE_CXX_FLAGS} -Wno-uninitialized")
+        set(CMAKE_CXX_FLAGS  "${CMAKE_CXX_FLAGS} -Wno-uninitialized")
+    endif( UNIX )
+
+    set(ProjectId "${ProjectId}_mpi")
+    project( ${ProjectId} )
+    message( STATUS "-- " ${ProjectId} )
+
+    file(GLOB_RECURSE ALL_SOURCE_FILES *.cpp *.h)
+
+    set(PACK_LIB "${ProjectId}_lib")
+    add_library(${PACK_LIB} STATIC ${ALL_SOURCE_FILES} )
+
+    add_executable( ${ProjectId} ${ALL_SOURCE_FILES} )
+
+    target_link_libraries(${ProjectId} ${PACK_LIB})
+    if( MPI_COMPILE_FLAGS )
+        set_target_properties( ${ProjectId} PROPERTIES COMPILE_FLAGS "${MPI_COMPILE_FLAGS}" )
+    endif( MPI_COMPILE_FLAGS )
+
+    if( MPI_LINK_FLAGS )
+        set_target_properties( ${ProjectId} PROPERTIES LINK_FLAGS "${MPI_LINK_FLAGS}" )
+    endif( MPI_LINK_FLAGS )
+    target_link_libraries( ${ProjectId} ${MPI_LIBRARIES} )
+    target_link_libraries(${ProjectId} gtest gtest_main boost_mpi)
+
+    enable_testing()
+    add_test(NAME ${ProjectId} COMMAND ${ProjectId})
+
+    CPPCHECK_AND_COUNTS_TESTS("${ProjectId}" "${ALL_SOURCE_FILES}")
+else( USE_MPI )
+    message( STATUS "-- ${ProjectId} - NOT BUILD!"  )
+endif( USE_MPI )

--- a/tasks/task_3/kostanyan_a_radix_sort_batcher/batcher_merge.cpp
+++ b/tasks/task_3/kostanyan_a_radix_sort_batcher/batcher_merge.cpp
@@ -1,0 +1,68 @@
+// Copyright 2023 Kostanyan Arsen
+
+#include "/home/arkosta/ppc-2023-mpi/tasks/task_3/kostanyan_a_radix_sort_batcher/batcher_merge.h"
+
+void cmp_and_swap(double & first, double & second) {
+    if (first > second) {
+        std::swap(first, second);
+    }
+}
+
+void merge(double * input, int size, int seq_len, int start_ind = 0, int offset = 1) {
+    if (seq_len > 2) {
+        merge(input, size, seq_len / 2, start_ind, offset * 2);
+        merge(input, size, seq_len / 2, start_ind + offset, offset * 2);
+        int iter = start_ind;
+        for (int i = 1;  i < seq_len - 1; i++) {
+        cmp_and_swap(input[iter], input[iter + offset]);
+        iter += offset;
+        }
+    } else {
+        cmp_and_swap(input[start_ind], input[start_ind + offset]);
+    }
+}
+
+int find_size_of_pow2(int val1, int val2) {
+    int val = std::max(val1, val2);
+    if ((val & (val - 1))) {
+        val = (1 << static_cast<int>(std::log2(val)+1));
+    }
+    return val;
+}
+
+bool is_pow2(int val) {
+    return (!(val & (val - 1)));
+}
+
+
+std::vector<double> batcher_merge(std::vector<double> first, std::vector<double> second) {
+    std::vector<double> output;
+
+    if (first.size() == second.size() && is_pow2(first.size())) {
+        output.insert(output.end(), first.begin(), first.end());
+        output.insert(output.end(), second.begin(), second.end());
+        merge(output.data(), output.size(), output.size());
+    } else {
+        int vec_len = find_size_of_pow2(first.size(), second.size());
+        int add1 = vec_len - first.size();
+        int add2 = vec_len - second.size();
+        output.insert(output.end(), first.begin(), first.end());
+        for (int i = 0; i < add1; i++) output.push_back(DBL_MAX);
+        output.insert(output.end(), second.begin(), second.end());
+        for (int i = 0; i < add2; i++) output.push_back(DBL_MAX);
+        merge(output.data(), output.size(), output.size());
+        output.erase(output.end() - add1 - add2, output.end());
+    }
+    return output;
+}
+
+std::vector<double> seq_batcher_merges(std::vector<std::vector<double>> vecs) {
+    int i = 0;
+    while (vecs.size() > 1) {
+        if (i + 1 == vecs.size()) i = 0;
+        vecs[i] = batcher_merge(vecs[i], vecs[i + 1]);
+        vecs.erase(vecs.begin() + i + 1);
+        if (i + 1 != vecs.size()) i++;
+    }
+    return vecs[0];
+}

--- a/tasks/task_3/kostanyan_a_radix_sort_batcher/batcher_merge.cpp
+++ b/tasks/task_3/kostanyan_a_radix_sort_batcher/batcher_merge.cpp
@@ -1,6 +1,6 @@
 // Copyright 2023 Kostanyan Arsen
 
-#include "/home/arkosta/ppc-2023-mpi/tasks/task_3/kostanyan_a_radix_sort_batcher/batcher_merge.h"
+#include "task_3/kostanyan_a_radix_sort_batcher/batcher_merge.h"
 
 void cmp_and_swap(double & first, double & second) {
     if (first > second) {

--- a/tasks/task_3/kostanyan_a_radix_sort_batcher/batcher_merge.h
+++ b/tasks/task_3/kostanyan_a_radix_sort_batcher/batcher_merge.h
@@ -1,0 +1,15 @@
+// Copyright 2023 Kostanyan Arsen
+
+#ifndef TASKS_TASK_3_KOSTANYAN_A_RADIX_SORT_BATCHER_BATCHER_MERGE_H_
+#define TASKS_TASK_3_KOSTANYAN_A_RADIX_SORT_BATCHER_BATCHER_MERGE_H_
+
+#include <vector>
+#include <iostream>
+#include <cfloat>
+#include <cmath>
+#include <utility>
+#include <algorithm>
+
+std::vector<double> seq_batcher_merges(std::vector<std::vector<double>> vecs);
+
+#endif  // TASKS_TASK_3_KOSTANYAN_A_RADIX_SORT_BATCHER_BATCHER_MERGE_H_

--- a/tasks/task_3/kostanyan_a_radix_sort_batcher/batcher_merge.h
+++ b/tasks/task_3/kostanyan_a_radix_sort_batcher/batcher_merge.h
@@ -1,7 +1,7 @@
 // Copyright 2023 Kostanyan Arsen
 
-#ifndef TASK_3_KOSTANYAN_A_RADIX_SORT_BATCHER_BATCHER_MERGE_H_
-#define TASK_3_KOSTANYAN_A_RADIX_SORT_BATCHER_BATCHER_MERGE_H_
+#ifndef TASKS_TASK_3_KOSTANYAN_A_RADIX_SORT_BATCHER_BATCHER_MERGE_H_
+#define TASKS_TASK_3_KOSTANYAN_A_RADIX_SORT_BATCHER_BATCHER_MERGE_H_
 
 #include <vector>
 #include <iostream>
@@ -12,4 +12,4 @@
 
 std::vector<double> seq_batcher_merges(std::vector<std::vector<double>> vecs);
 
-#endif  // TASK_3_KOSTANYAN_A_RADIX_SORT_BATCHER_BATCHER_MERGE_H_
+#endif  // TASKS_TASK_3_KOSTANYAN_A_RADIX_SORT_BATCHER_BATCHER_MERGE_H_

--- a/tasks/task_3/kostanyan_a_radix_sort_batcher/batcher_merge.h
+++ b/tasks/task_3/kostanyan_a_radix_sort_batcher/batcher_merge.h
@@ -1,7 +1,7 @@
 // Copyright 2023 Kostanyan Arsen
 
-#ifndef TASKS_TASK_3_KOSTANYAN_A_RADIX_SORT_BATCHER_BATCHER_MERGE_H_
-#define TASKS_TASK_3_KOSTANYAN_A_RADIX_SORT_BATCHER_BATCHER_MERGE_H_
+#ifndef TASK_3_KOSTANYAN_A_RADIX_SORT_BATCHER_BATCHER_MERGE_H_
+#define TASK_3_KOSTANYAN_A_RADIX_SORT_BATCHER_BATCHER_MERGE_H_
 
 #include <vector>
 #include <iostream>
@@ -12,4 +12,4 @@
 
 std::vector<double> seq_batcher_merges(std::vector<std::vector<double>> vecs);
 
-#endif  // TASKS_TASK_3_KOSTANYAN_A_RADIX_SORT_BATCHER_BATCHER_MERGE_H_
+#endif  // TASK_3_KOSTANYAN_A_RADIX_SORT_BATCHER_BATCHER_MERGE_H_

--- a/tasks/task_3/kostanyan_a_radix_sort_batcher/main.cpp
+++ b/tasks/task_3/kostanyan_a_radix_sort_batcher/main.cpp
@@ -1,0 +1,93 @@
+// Copyright 2023 Kostanyan Arsen
+#include <gtest/gtest.h>
+#include <string>
+#include <random>
+#include <iostream>
+#include "/home/arkosta/ppc-2023-mpi/tasks/task_3/kostanyan_a_radix_sort_batcher/batcher_merge.h"
+#include "/home/arkosta/ppc-2023-mpi/tasks/task_3/kostanyan_a_radix_sort_batcher/radix_batcher.h"
+
+TEST(TEST_MPI, Test_Radix_Sort) {
+    int rank;
+    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+    if (rank == 0) {
+        int vec_size = 30;
+        std::vector<double> unsorted_vec = generateRandomVector(vec_size * vec_size);
+        radix_sort(unsorted_vec.data(), unsorted_vec.size());
+        for (int i = 0; i < unsorted_vec.size() - 1; i++) {
+            ASSERT_LE(unsorted_vec[i], unsorted_vec[i+1]);
+        }
+    }
+}
+
+TEST(TEST_MPI, Test_Batcher_Merge_Not_Power_2) {
+    int rank, size;
+    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+    MPI_Comm_size(MPI_COMM_WORLD, &size);
+    int vec_size = 200;
+    std::vector<double> unsorted_vec = generateRandomVector(size * vec_size);
+    std::vector<double> sorted_vec = parallel_radix_batcher_sort(unsorted_vec);
+    if (rank == 0) {
+        for (int i = 0; i < sorted_vec.size() - 1; i++) {
+            ASSERT_LE(sorted_vec[i], sorted_vec[i+1]);
+        }
+    }
+}
+
+
+TEST(TEST_MPI, Test_Batcher__Power_2) {
+    int rank, size;
+    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+    MPI_Comm_size(MPI_COMM_WORLD, &size);
+    int vec_size = 256;
+    std::vector<double> unsorted_vec = generateRandomVector(size * vec_size);
+    std::vector<double> sorted_vec = parallel_radix_batcher_sort(unsorted_vec);
+    if (rank == 0) {
+        for (int i = 0; i < sorted_vec.size() - 1; i++) {
+            ASSERT_LE(sorted_vec[i], sorted_vec[i+1]);
+        }
+    }
+}
+
+TEST(TEST_MPI, Test_If_Merge_1) {
+    int rank, size;
+    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+    MPI_Comm_size(MPI_COMM_WORLD, &size);
+    int vec_size = 10;
+    std::vector<double> unsorted_vec = generateRandomVector(size * vec_size);
+    std::vector<double> sorted_vec = parallel_radix_batcher_sort(unsorted_vec);
+    if (rank == 0) {
+        for (int i = 0; i < sorted_vec.size() - 1; i++) {
+            ASSERT_LE(sorted_vec[i], sorted_vec[i+1]);
+        }
+    }
+}
+
+TEST(TEST_MPI, Test_Long) {
+    int rank, size;
+    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+    MPI_Comm_size(MPI_COMM_WORLD, &size);
+    int vec_size = 1500;
+    std::vector<double> unsorted_vec = generateRandomVector(size * vec_size);
+    std::vector<double> sorted_vec = parallel_radix_batcher_sort(unsorted_vec);
+    if (rank == 0) {
+        for (int i = 0; i < sorted_vec.size() - 1; i++) {
+            ASSERT_LE(sorted_vec[i], sorted_vec[i+1]);
+        }
+    }
+}
+
+
+int main(int argc, char **argv) {
+    int result_code = 0;
+
+    ::testing::InitGoogleTest(&argc, argv);
+    ::testing::TestEventListeners &listeners =
+        ::testing::UnitTest::GetInstance()->listeners();
+
+    if (MPI_Init(&argc, &argv) != MPI_SUCCESS)
+        MPI_Abort(MPI_COMM_WORLD, -1);
+    result_code = RUN_ALL_TESTS();
+    MPI_Finalize();
+
+    return result_code;
+}

--- a/tasks/task_3/kostanyan_a_radix_sort_batcher/main.cpp
+++ b/tasks/task_3/kostanyan_a_radix_sort_batcher/main.cpp
@@ -3,8 +3,8 @@
 #include <string>
 #include <random>
 #include <iostream>
-#include "/home/arkosta/ppc-2023-mpi/tasks/task_3/kostanyan_a_radix_sort_batcher/batcher_merge.h"
-#include "/home/arkosta/ppc-2023-mpi/tasks/task_3/kostanyan_a_radix_sort_batcher/radix_batcher.h"
+#include "task_3/kostanyan_a_radix_sort_batcher/batcher_merge.h"
+#include "task_3/kostanyan_a_radix_sort_batcher/radix_batcher.h"
 
 TEST(TEST_MPI, Test_Radix_Sort) {
     int rank;

--- a/tasks/task_3/kostanyan_a_radix_sort_batcher/radix_batcher.cpp
+++ b/tasks/task_3/kostanyan_a_radix_sort_batcher/radix_batcher.cpp
@@ -1,0 +1,104 @@
+// Copyright 2023 Kostanyan Arsen
+
+#include "/home/arkosta/ppc-2023-mpi/tasks/task_3/kostanyan_a_radix_sort_batcher/radix_batcher.h"
+
+std::vector<double> generateRandomVector(int size) {
+    std::random_device dev;
+    std::mt19937 gen(dev());
+    std::vector<double> randomVector(size);
+
+    for (int i = 0; i < size; i++) {
+        double randomNumber = static_cast<double>(gen() % 1000) / (static_cast<double>(gen() % 1000) + 1);
+        if (static_cast<double>(gen() % 4) == 2) {
+            randomNumber *= -1;
+        }
+        randomVector[i] = randomNumber;
+    }
+
+    return randomVector;
+}
+std::vector<double> parallel_radix_batcher_sort(std::vector<double> to_sort_vec) {
+    int rank, size;
+    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+    MPI_Comm_size(MPI_COMM_WORLD, &size);
+    int vsize = to_sort_vec.size() / size;
+    std::vector<double> lvec(vsize);
+
+
+    MPI_Scatter(to_sort_vec.data(), vsize, MPI_DOUBLE,
+        lvec.data(), vsize, MPI_DOUBLE, 0, MPI_COMM_WORLD);
+
+    radix_sort(lvec.data(), lvec.size());
+
+    if (rank != 0) {
+        MPI_Send(lvec.data(), vsize, MPI_DOUBLE, 0, 0, MPI_COMM_WORLD);
+    } else {
+        std::vector<std::vector<double>> vbuff;
+        vbuff.push_back(lvec);
+        for (int i = 1; i < size; i++) {
+            MPI_Recv(lvec.data(), vsize, MPI_DOUBLE, i, 0, MPI_COMM_WORLD, MPI_STATUS_IGNORE);
+            vbuff.push_back(lvec);
+        }
+        return seq_batcher_merges(vbuff);
+    }
+    return lvec;
+}
+
+static union {
+    uint64_t bits;
+    double d;
+} value;
+
+void sorter(double * arr, int size, int iter, int base, int * negatives_cnt) {
+    double * local_arr = new double[size];
+    int * cnt = new int[base]();
+    int mask = base - 1;
+    (*negatives_cnt) = 0;
+    int ind;
+
+    for (int i = 0 ; i < size; i++) {
+        value.d = arr[i];
+        ind = (((value.bits) >> (8 * iter)) & mask);
+        cnt[ind]++;
+    }
+
+    for (int i = 1; i < base; i++) {
+        if (i >= (base >> 1) ) (*negatives_cnt)+=cnt[i];
+        cnt[i] += cnt[i - 1];
+    }
+
+    for (int i = size - 1; i >= 0; i--) {
+        value.d = arr[i];
+        ind = (((value.bits) >> (8 * iter)) & mask);
+        local_arr[cnt[ind] - 1] = arr[i];
+        cnt[ind]--;
+    }
+
+    for (int i = 0; i < size; i++)
+        arr[i] = local_arr[i];
+
+    delete[] local_arr;
+    delete[] cnt;
+}
+
+void radix_sort(double * arr, int size) {
+    int bits = 8;
+    int base = (1 << bits);
+    int iters = (sizeof(double) * 8) / bits;
+    int negatives = 0;
+
+    for (int i = 0; i < iters; i++) {
+        sorter(arr, size, i, base, &(negatives));
+    }
+
+    if (negatives == 0) return;
+
+    std::reverse(arr + size - negatives,
+                arr + size);
+    double * negatives_buff = new double[negatives];
+    memcpy(negatives_buff, (arr + size - negatives), negatives * sizeof(double));
+    memmove((arr + negatives), arr,
+        (size - negatives) * sizeof(double));
+    memcpy(arr, negatives_buff, negatives * sizeof(double));
+}
+

--- a/tasks/task_3/kostanyan_a_radix_sort_batcher/radix_batcher.cpp
+++ b/tasks/task_3/kostanyan_a_radix_sort_batcher/radix_batcher.cpp
@@ -1,6 +1,6 @@
 // Copyright 2023 Kostanyan Arsen
 
-#include "/home/arkosta/ppc-2023-mpi/tasks/task_3/kostanyan_a_radix_sort_batcher/radix_batcher.h"
+#include "task_3/kostanyan_a_radix_sort_batcher/radix_batcher.h"
 
 std::vector<double> generateRandomVector(int size) {
     std::random_device dev;

--- a/tasks/task_3/kostanyan_a_radix_sort_batcher/radix_batcher.h
+++ b/tasks/task_3/kostanyan_a_radix_sort_batcher/radix_batcher.h
@@ -1,7 +1,7 @@
 // Copyright 2023 Kostanyan Arsen
 
-#ifndef TASK_3_KOSTANYAN_A_RADIX_SORT_BATCHER_RADIX_BATCHER_H_
-#define TASK_3_KOSTANYAN_A_RADIX_SORT_BATCHER_RADIX_BATCHER_H_
+#ifndef TASKS_TASK_3_KOSTANYAN_A_RADIX_SORT_BATCHER_RADIX_BATCHER_H_
+#define TASKS_TASK_3_KOSTANYAN_A_RADIX_SORT_BATCHER_RADIX_BATCHER_H_
 
 #include <mpi.h>
 #include <vector>
@@ -17,4 +17,4 @@ std::vector<double> parallel_radix_batcher_sort(std::vector<double> to_sort_vec)
 
 void radix_sort(double * arr, int size);
 
-#endif  // TASK_3_KOSTANYAN_A_RADIX_SORT_BATCHER_RADIX_BATCHER_H_
+#endif  // TASKS_TASK_3_KOSTANYAN_A_RADIX_SORT_BATCHER_RADIX_BATCHER_H_

--- a/tasks/task_3/kostanyan_a_radix_sort_batcher/radix_batcher.h
+++ b/tasks/task_3/kostanyan_a_radix_sort_batcher/radix_batcher.h
@@ -1,7 +1,7 @@
 // Copyright 2023 Kostanyan Arsen
 
-#ifndef TASKS_TASK_3_KOSTANYAN_A_RADIX_SORT_BATCHER_RADIX_BATCHER_H_
-#define TASKS_TASK_3_KOSTANYAN_A_RADIX_SORT_BATCHER_RADIX_BATCHER_H_
+#ifndef TASK_3_KOSTANYAN_A_RADIX_SORT_BATCHER_RADIX_BATCHER_H_
+#define TASK_3_KOSTANYAN_A_RADIX_SORT_BATCHER_RADIX_BATCHER_H_
 
 #include <mpi.h>
 #include <vector>
@@ -10,11 +10,11 @@
 #include <algorithm>
 #include <cstring>
 
-#include "/home/arkosta/ppc-2023-mpi/tasks/task_3/kostanyan_a_radix_sort_batcher/batcher_merge.h"
+#include "task_3/kostanyan_a_radix_sort_batcher/batcher_merge.h"
 
 std::vector<double> generateRandomVector(int size);
 std::vector<double> parallel_radix_batcher_sort(std::vector<double> to_sort_vec);
 
 void radix_sort(double * arr, int size);
 
-#endif  // TASKS_TASK_3_KOSTANYAN_A_RADIX_SORT_BATCHER_RADIX_BATCHER_H_
+#endif  // TASK_3_KOSTANYAN_A_RADIX_SORT_BATCHER_RADIX_BATCHER_H_

--- a/tasks/task_3/kostanyan_a_radix_sort_batcher/radix_batcher.h
+++ b/tasks/task_3/kostanyan_a_radix_sort_batcher/radix_batcher.h
@@ -1,0 +1,20 @@
+// Copyright 2023 Kostanyan Arsen
+
+#ifndef TASKS_TASK_3_KOSTANYAN_A_RADIX_SORT_BATCHER_RADIX_BATCHER_H_
+#define TASKS_TASK_3_KOSTANYAN_A_RADIX_SORT_BATCHER_RADIX_BATCHER_H_
+
+#include <mpi.h>
+#include <vector>
+#include <random>
+#include <string>
+#include <algorithm>
+#include <cstring>
+
+#include "/home/arkosta/ppc-2023-mpi/tasks/task_3/kostanyan_a_radix_sort_batcher/batcher_merge.h"
+
+std::vector<double> generateRandomVector(int size);
+std::vector<double> parallel_radix_batcher_sort(std::vector<double> to_sort_vec);
+
+void radix_sort(double * arr, int size);
+
+#endif  // TASKS_TASK_3_KOSTANYAN_A_RADIX_SORT_BATCHER_RADIX_BATCHER_H_


### PR DESCRIPTION
Программа реализует поразрядную сортировку для вещественных чисел типа double с использованием четно-нечетного слияния Бэтчера. Код включает функции для генерации случайного вектора вещественных чисел, а также параллельной сортировки с использованием библиотеки MPI.

`generateRandomVector`: Генерирует случайный вектор вещественных чисел.

`parallel_radix_batcher_sort:` Разделяет входной вектор между процессами MPI, выполняет поразрядную сортировку на каждом процессе, затем сливает отсортированные подвекторы с использованием четно-нечетного слияния Бэтчера.

`radix_sort`: Реализует поразрядную сортировку для вещественных чисел типа double.

`batcher_merge`: Выполняет четно-нечетное слияние Бэтчера для двух векторов.

`seq_batcher_merges`: Последовательно выполняет четно-нечетное слияние Бэтчера для нескольких векторов, пока не останется один отсортированный вектор.