### PR TITLE
Кудинов Никита. Задача 3. Вариант 28. Линейная фильтрация изображений (блочное разбиение). Ядро Гаусса 3x3.

### DIFF
--- a/tasks/task_3/kudinov_n_image_filter_gauss_block/CMakeLists.txt
+++ b/tasks/task_3/kudinov_n_image_filter_gauss_block/CMakeLists.txt
@@ -1,0 +1,38 @@
+get_filename_component(ProjectId ${CMAKE_CURRENT_SOURCE_DIR} NAME)
+enable_testing()
+
+if( USE_MPI )
+    if( UNIX )
+        set(CMAKE_C_FLAGS  "${CMAKE_CXX_FLAGS} -Wno-uninitialized")
+        set(CMAKE_CXX_FLAGS  "${CMAKE_CXX_FLAGS} -Wno-uninitialized")
+    endif( UNIX )
+
+    set(ProjectId "${ProjectId}_mpi")
+    project( ${ProjectId} )
+    message( STATUS "-- " ${ProjectId} )
+
+    file(GLOB_RECURSE ALL_SOURCE_FILES *.cpp *.h)
+
+    set(PACK_LIB "${ProjectId}_lib")
+    add_library(${PACK_LIB} STATIC ${ALL_SOURCE_FILES} )
+
+    add_executable( ${ProjectId} ${ALL_SOURCE_FILES} )
+
+    target_link_libraries(${ProjectId} ${PACK_LIB})
+    if( MPI_COMPILE_FLAGS )
+        set_target_properties( ${ProjectId} PROPERTIES COMPILE_FLAGS "${MPI_COMPILE_FLAGS}" )
+    endif( MPI_COMPILE_FLAGS )
+
+    if( MPI_LINK_FLAGS )
+        set_target_properties( ${ProjectId} PROPERTIES LINK_FLAGS "${MPI_LINK_FLAGS}" )
+    endif( MPI_LINK_FLAGS )
+    target_link_libraries( ${ProjectId} ${MPI_LIBRARIES} )
+    target_link_libraries(${ProjectId} gtest gtest_main boost_mpi)
+
+    enable_testing()
+    add_test(NAME ${ProjectId} COMMAND ${ProjectId})
+
+    CPPCHECK_AND_COUNTS_TESTS("${ProjectId}" "${ALL_SOURCE_FILES}")
+else( USE_MPI )
+    message( STATUS "-- ${ProjectId} - NOT BUILD!"  )
+endif( USE_MPI )

--- a/tasks/task_3/kudinov_n_image_filter_gauss_block/image_filter_gauss_block.cpp
+++ b/tasks/task_3/kudinov_n_image_filter_gauss_block/image_filter_gauss_block.cpp
@@ -1,0 +1,374 @@
+// Copyright 2023 Kudinov Nikita
+#include "task_3/kudinov_n_image_filter_gauss_block/image_filter_gauss_block.h"
+
+#include <iostream>
+#include <iomanip>
+#include <cmath>
+#include <utility>
+#include <random>
+#include <functional>
+
+#include <boost/mpi.hpp>
+#include <boost/serialization/utility.hpp>
+#include <boost/serialization/vector.hpp>
+
+Image generate_random_image(const std::size_t height, const std::size_t width) {
+    std::random_device dev;
+    std::mt19937 gen(dev());
+    Image out(height, std::vector<Pixel>(width, 0));
+
+    for (std::size_t i = 0; i < height; i += 1) {
+        for (std::size_t j = 0; j < width; j += 1) {
+            out[i][j] = gen() % 255;
+        }
+    }
+
+    return out;
+}
+
+std::pair<std::size_t, std::size_t> get_image_segments_dimensions(const std::size_t world_size) {
+    std::size_t start = std::sqrt(world_size);
+
+    while (world_size % start != 0) {
+        start -= 1;
+    }
+
+    return std::make_pair(start, world_size / start);
+}
+
+void image_print(const Image& image) {
+    for (std::size_t i = 0; i < image.size(); i += 1) {
+        for (std::size_t j = 0; j < image[i].size(); j += 1) {
+            std::cout << std::setw(3) << +image[i][j] << ' ';
+        }
+        std::cout << '\n';
+    }
+    std::cout << std::endl;
+}
+
+Image image_get_subimage(
+    const Image& image,
+    const std::size_t y,
+    const std::size_t x,
+    const std::size_t height,
+    const std::size_t width) {
+    if (y + height > image.size() || x + width > image[0].size()) {
+        throw std::runtime_error("Subimage is out of bounds");
+    }
+
+    Image out(height, std::vector<Pixel>(width, 0));
+
+    for (std::size_t i = y; i < y + height; i += 1) {
+        for (std::size_t j = x; j < x + width; j += 1) {
+            out[i - y][j - x] = image[i][j];
+        }
+    }
+
+    return out;
+}
+
+Image concat_images_horizontal(const std::vector<Image>& images) {
+    // Images must be with the same height
+    std::size_t out_width = 0;
+    for (const Image& image : images) {
+        out_width += image[0].size();
+    }
+
+    Image out(images[0].size(), std::vector<Pixel>(out_width, 0));
+
+    std::size_t x = 0;
+    for (std::size_t k = 0; k < images.size(); k += 1) {
+        const Image& image = images[k];
+
+        for (std::size_t i = 0; i < image.size(); i += 1) {
+            for (std::size_t j = 0; j < image[i].size(); j += 1) {
+                out[i][x + j] = image[i][j];
+            }
+        }
+
+        x += image[0].size();
+    }
+
+    return out;
+}
+
+Image concat_images_vertical(const std::vector<Image>& images) {
+    // Images must be with the same width
+    std::size_t out_height = 0;
+    for (const Image& image : images) {
+        out_height += image.size();
+    }
+
+    Image out(out_height, std::vector<Pixel>(images[0][0].size(), 0));
+
+    std::size_t y = 0;
+    for (std::size_t k = 0; k < images.size(); k += 1) {
+        const Image& image = images[k];
+
+        for (std::size_t i = 0; i < image.size(); i += 1) {
+            for (std::size_t j = 0; j < image[i].size(); j += 1) {
+                out[y + i][j] = image[i][j];
+            }
+        }
+
+        y += image.size();
+    }
+
+    return out;
+}
+
+std::vector<std::vector<double>> generate_gauss_kernel(
+    const std::size_t kernel_radius,
+    const double sigma) {
+    const std::size_t kernel_size = kernel_radius * 2 + 1;
+    std::vector<std::vector<double>> kernel(kernel_size, std::vector<double>(kernel_size, 0.0));
+
+    double sum = 0.0;
+    for (std::size_t i = 0; i < kernel_size; i += 1) {
+        for (std::size_t j = 0; j < kernel_size; j += 1) {
+            const double dist_x = std::pow(static_cast<double>(i - kernel_radius), 2.0);
+            const double dist_y = std::pow(static_cast<double>(j - kernel_radius), 2.0);
+
+            const double coef = std::exp(-(dist_x + dist_y) / (2.0 * std::pow(sigma, 2.0)));
+            kernel[i][j] = coef;
+            sum += coef;
+        }
+    }
+
+    for (std::size_t i = 0; i < kernel_size; i += 1) {
+        for (std::size_t j = 0; j < kernel_size; j += 1) {
+            kernel[i][j] /= sum;
+        }
+    }
+
+    return kernel;
+}
+
+Pixel image_get_gauss_filtered_pixel(
+    const Image& image,
+    const std::vector<std::vector<double>>& kernel,
+    const std::size_t y,
+    const std::size_t x) {
+    Pixel result_pixel = 0;
+
+    std::size_t kernel_radius = kernel.size() / 2;
+
+    for (std::size_t i = 0; i < kernel.size(); i += 1) {
+        for (std::size_t j = 0; j < kernel.size(); j += 1) {
+            const Pixel pixel = image
+                [std::clamp<std::size_t>(y - kernel_radius + i, 0, image.size() - 1)]
+                [std::clamp<std::size_t>(x - kernel_radius + j, 0, image[0].size() - 1)];
+
+            result_pixel += std::clamp<Pixel>(
+                kernel[i][j] * static_cast<double>(pixel),
+                0,
+                UINT8_MAX);
+        }
+    }
+
+    return result_pixel;
+}
+
+void image_apply_gauss_filter_on_borders(
+    const Image& image,
+    const std::vector<std::vector<double>>& kernel,
+    Image* out,
+    const std::size_t subimage_y,
+    const std::size_t subimage_x,
+    const std::size_t subimage_height,
+    const std::size_t subimage_width) {
+    std::size_t kernel_radius = kernel.size() / 2;
+
+    // Top Left Corner
+    for (std::size_t y = subimage_y; y < subimage_y + kernel_radius; y += 1) {
+        for (std::size_t x = subimage_x; x < subimage_x + kernel_radius; x += 1) {
+            (*out)[y][x] = image_get_gauss_filtered_pixel(image, kernel, y, x);
+        }
+    }
+
+    // Bottom Left Corner
+    for (std::size_t y = subimage_y + subimage_height - kernel_radius; y < subimage_y + subimage_height; y += 1) {
+        for (std::size_t x = subimage_x; x < subimage_x + kernel_radius; x += 1) {
+            (*out)[y][x] = image_get_gauss_filtered_pixel(image, kernel, y, x);
+        }
+    }
+
+    // Top Right Corner
+    for (std::size_t y = subimage_y; y < subimage_y + kernel_radius; y += 1) {
+        for (std::size_t x = subimage_x + subimage_width - kernel_radius; x < subimage_x + subimage_width; x += 1) {
+            (*out)[y][x] = image_get_gauss_filtered_pixel(image, kernel, y, x);
+        }
+    }
+
+    // Bottom Right Corner
+    for (std::size_t y = subimage_y + subimage_height - kernel_radius; y < subimage_y + subimage_height; y += 1) {
+        for (std::size_t x = subimage_x + subimage_width - kernel_radius; x < subimage_x + subimage_width; x += 1) {
+            (*out)[y][x] = image_get_gauss_filtered_pixel(image, kernel, y, x);
+        }
+    }
+
+    // Top Horizontal Border
+    for (std::size_t y = subimage_y; y < subimage_y + kernel_radius; y += 1) {
+        for (std::size_t x = subimage_x + kernel_radius; x < subimage_x + subimage_width - kernel_radius; x += 1) {
+            (*out)[y][x] = image_get_gauss_filtered_pixel(image, kernel, y, x);
+        }
+    }
+
+    // Bottom Horizontal Border
+    for (std::size_t y = subimage_y + subimage_height - kernel_radius; y < subimage_y + subimage_height; y += 1) {
+        for (std::size_t x = subimage_x + kernel_radius; x < subimage_x + subimage_width - kernel_radius; x += 1) {
+            (*out)[y][x] = image_get_gauss_filtered_pixel(image, kernel, y, x);
+        }
+    }
+
+    // Left Vertical Border
+    for (std::size_t y = subimage_y + kernel_radius; y < subimage_y + subimage_height - kernel_radius; y += 1) {
+        for (std::size_t x = subimage_x; x < subimage_x + kernel_radius; x += 1) {
+            (*out)[y][x] = image_get_gauss_filtered_pixel(image, kernel, y, x);
+        }
+    }
+
+    // Right Vertical Border
+    for (std::size_t y = subimage_y + kernel_radius; y < subimage_y + subimage_height - kernel_radius; y += 1) {
+        for (std::size_t x = subimage_x + subimage_width - kernel_radius; x < subimage_x + subimage_width; x += 1) {
+            (*out)[y][x] = image_get_gauss_filtered_pixel(image, kernel, y, x);
+        }
+    }
+}
+
+Image image_gauss_filter_sequential(
+    const Image& image,
+    const std::size_t kernel_radius,
+    const double sigma,
+    const bool with_borders) {
+    if (image.empty() || image[0].empty()) return {};
+
+    Image out(image.size(), std::vector<Pixel>(image[0].size(), 0));
+
+    const std::vector<std::vector<double>> kernel = generate_gauss_kernel(kernel_radius, sigma);
+
+    for (
+        std::size_t y = kernel_radius;
+        y < image.size() - kernel_radius;
+        y += 1) {
+        for (
+            std::size_t x = kernel_radius;
+            x < image[y].size() - kernel_radius;
+            x += 1) {
+            out[y][x] = image_get_gauss_filtered_pixel(image, kernel, y, x);
+        }
+    }
+
+    if (with_borders) {
+        image_apply_gauss_filter_on_borders(
+            image,
+            kernel,
+            &out,
+            0,
+            0,
+            image.size(),
+            image[0].size());
+    }
+
+    return out;
+}
+
+Image image_gauss_filter_parallel(
+    const Image& image,
+    const std::size_t kernel_radius,
+    const double sigma) {
+    if (image.empty() || image[0].empty()) return {};
+
+    boost::mpi::communicator world;
+    std::vector<std::vector<double>> kernel = generate_gauss_kernel(kernel_radius, sigma);
+
+    std::pair<std::size_t, std::size_t> image_segments_dimensions = get_image_segments_dimensions(world.size());
+    std::size_t height_segment_size, width_segment_size;
+    if (image.size() > image[0].size()) {
+        height_segment_size = image_segments_dimensions.second;
+        width_segment_size = image_segments_dimensions.first;
+    } else {
+        height_segment_size = image_segments_dimensions.first;
+        width_segment_size = image_segments_dimensions.second;
+    }
+
+    std::size_t segment_height = image.size() / height_segment_size;
+    std::size_t segment_width = image[0].size() / width_segment_size;
+
+    std::vector<Image> segments;
+    Image local_segment;
+    if (world.rank() == 0) {
+        std::size_t i, segment_position_y;
+        for (i = 0, segment_position_y = 0; i < height_segment_size; i += 1, segment_position_y += segment_height) {
+            std::size_t new_segment_height = i == height_segment_size - 1
+                ? image.size() - segment_position_y
+                : segment_height;
+
+            std::size_t j, segment_position_x;
+            for (j = 0, segment_position_x = 0; j < width_segment_size; j += 1, segment_position_x += segment_width) {
+                std::size_t new_segment_width = j == width_segment_size - 1
+                    ? image[0].size() - segment_position_x
+                    : segment_width;
+
+                Image subimage = image_get_subimage(
+                    image,
+                    segment_position_y,
+                    segment_position_x,
+                    new_segment_height,
+                    new_segment_width);
+
+                segments.push_back(subimage);
+            }
+        }
+    }
+
+    boost::mpi::scatter(world, segments, local_segment, 0);
+
+    Image local_result = image_gauss_filter_sequential(local_segment, kernel_radius, sigma, false);
+
+    std::vector<Image> global_result;
+    boost::mpi::gather(world, local_result, global_result, 0);
+
+    Image gathered_image;
+    if (world.rank() == 0) {
+        std::vector<Image> rows;
+        std::size_t count = 0;
+        for (std::size_t i = 0; i < height_segment_size; i += 1) {
+            std::vector<Image> horizontal_segments;
+
+            for (std::size_t j = 0; j < width_segment_size; j += 1) {
+                horizontal_segments.push_back(global_result[count]);
+                count += 1;
+            }
+
+            rows.push_back(concat_images_horizontal(horizontal_segments));
+        }
+
+        gathered_image = concat_images_vertical(rows);
+
+        std::size_t i, segment_position_y;
+        for (i = 0, segment_position_y = 0; i < height_segment_size; i += 1, segment_position_y += segment_height) {
+            std::size_t new_segment_height = i == height_segment_size - 1
+                ? image.size() - segment_position_y
+                : segment_height;
+
+            std::size_t j, segment_position_x;
+            for (j = 0, segment_position_x = 0; j < width_segment_size; j += 1, segment_position_x += segment_width) {
+                std::size_t new_segment_width = j == width_segment_size - 1
+                    ? image[0].size() - segment_position_x
+                    : segment_width;
+
+                image_apply_gauss_filter_on_borders(
+                    image,
+                    kernel,
+                    &gathered_image,
+                    segment_position_y,
+                    segment_position_x,
+                    new_segment_height,
+                    new_segment_width);
+            }
+        }
+    }
+
+    return gathered_image;
+}

--- a/tasks/task_3/kudinov_n_image_filter_gauss_block/image_filter_gauss_block.h
+++ b/tasks/task_3/kudinov_n_image_filter_gauss_block/image_filter_gauss_block.h
@@ -1,0 +1,58 @@
+// Copyright 2023 Kudinov Nikita
+#ifndef TASKS_TASK_3_KUDINOV_N_IMAGE_FILTER_GAUSS_BLOCK_IMAGE_FILTER_GAUSS_BLOCK_H_
+#define TASKS_TASK_3_KUDINOV_N_IMAGE_FILTER_GAUSS_BLOCK_IMAGE_FILTER_GAUSS_BLOCK_H_
+
+#include <cstdint>
+#include <vector>
+#include <utility>
+
+using Pixel = std::uint8_t;
+using Image = std::vector<std::vector<Pixel>>;
+
+Image generate_random_image(const std::size_t height, const std::size_t width);
+
+std::pair<std::size_t, std::size_t> get_image_segments_dimensions(const std::size_t world_size);
+
+void image_print(const Image& image);
+
+Image image_get_subimage(
+    const Image& image,
+    const std::size_t y,
+    const std::size_t x,
+    const std::size_t height,
+    const std::size_t width);
+
+Image concat_images_horizontal(const std::vector<Image>& images);
+Image concat_images_vertical(const std::vector<Image>& images);
+
+std::vector<std::vector<double>> generate_gauss_kernel(
+    const std::size_t kernel_radius,
+    const double sigma);
+
+Pixel image_get_gauss_filtered_pixel(
+    const Image& image,
+    const std::vector<std::vector<double>>& kernel,
+    const std::size_t y,
+    const std::size_t x);
+
+void image_apply_gauss_filter_on_borders(
+    const Image& image,
+    const std::vector<std::vector<double>>& kernel,
+    Image* out,
+    const std::size_t subimage_y,
+    const std::size_t subimage_x,
+    const std::size_t subimage_height,
+    const std::size_t subimage_width);
+
+Image image_gauss_filter_sequential(
+    const Image& image,
+    const std::size_t kernel_radius = 1,
+    const double sigma = 1.0,
+    const bool with_borders = true);
+
+Image image_gauss_filter_parallel(
+    const Image& image,
+    const std::size_t kernel_radius = 1,
+    const double sigma = 1.0);
+
+#endif  // TASKS_TASK_3_KUDINOV_N_IMAGE_FILTER_GAUSS_BLOCK_IMAGE_FILTER_GAUSS_BLOCK_H_

--- a/tasks/task_3/kudinov_n_image_filter_gauss_block/main.cpp
+++ b/tasks/task_3/kudinov_n_image_filter_gauss_block/main.cpp
@@ -1,0 +1,103 @@
+// Copyright 2023 Kudinov Nikita
+#include <gtest/gtest.h>
+#include <boost/mpi.hpp>
+
+#include "task_3/kudinov_n_image_filter_gauss_block/image_filter_gauss_block.h"
+
+#define ASSERT_EQ_IMAGES(image1, image2)                                \
+    do {                                                                \
+        ASSERT_EQ(image1.size(), image2.size());                        \
+        if (image1.size() != 0) {                                       \
+            ASSERT_EQ(image1[0].size(), image2[0].size());              \
+                                                                        \
+            for (std::size_t y = 0; y < image1.size(); y += 1) {        \
+                for (std::size_t x = 0; x < image1[0].size(); x += 1) { \
+                    ASSERT_EQ(image1[y][x], image2[y][x]);              \
+                }                                                       \
+            }                                                           \
+        }                                                               \
+    } while (0)
+
+void base_test(const Image& image, std::size_t kernel_radius, double sigma) {
+    boost::mpi::communicator world;
+
+    Image result_parallel = image_gauss_filter_parallel(image, kernel_radius, sigma);
+
+    if (world.rank() == 0) {
+        Image result_sequential = image_gauss_filter_sequential(image, kernel_radius, sigma);
+
+        ASSERT_EQ_IMAGES(result_sequential, result_parallel);
+    }
+}
+
+TEST(Matrix_Multiplication_Vertical, Small_Image_Square) {
+    Image image = {{ 59, 2, 130, 50, 76, 17, 226, 35, 105, 183, 237, 212 },
+        { 227, 160, 247, 94, 104, 59, 178, 250, 234, 91, 108, 12 },
+        { 134, 197, 22, 104, 72, 21, 67, 11, 128, 31, 11, 243 },
+        { 167, 95, 213, 96, 180, 17, 93, 25, 179, 235, 178, 163 },
+        { 101, 119, 160, 237, 232, 181, 229, 237, 100, 204, 160, 76 },
+        { 229, 56, 61, 48, 222, 34, 27, 85, 254, 44, 232, 128 },
+        { 217, 254, 85, 115, 135, 72, 225, 1, 90, 66, 4, 221 },
+        { 21, 252, 198, 24, 80, 246, 237, 92, 162, 177, 102, 130 },
+        { 177, 32, 61, 234, 167, 178, 109, 209, 55, 134, 182, 222 },
+        { 77, 17, 145, 22, 192, 58, 65, 39, 177, 90, 219, 88 },
+        { 185, 140, 142, 201, 238, 252, 33, 41, 3, 152, 126, 176 },
+        { 164, 44, 8, 207, 204, 81, 202, 72, 175, 116, 128, 161}};
+
+    base_test(image, 2, 1.4);
+}
+
+TEST(Matrix_Multiplication_Vertical, Small_Random_Image_Square) {
+    Image image = generate_random_image(9, 9);
+
+    base_test(image, 3, 1.2);
+}
+
+TEST(Matrix_Multiplication_Vertical, Small_Random_Image_Rect) {
+    Image image = generate_random_image(9, 13);
+
+    base_test(image, 1, 2.2);
+}
+
+TEST(Matrix_Multiplication_Vertical, Medium_Random_Image_Rect) {
+    Image image = generate_random_image(63, 68);
+
+    base_test(image, 3, 1.8);
+}
+
+TEST(Matrix_Multiplication_Vertical, Medium_Random_Image_Square) {
+    Image image = generate_random_image(70, 70);
+
+    base_test(image, 3, 1.8);
+}
+
+TEST(Matrix_Multiplication_Vertical, Big_Random_Matrix_Rect) {
+    Image image = generate_random_image(201, 203);
+
+    base_test(image, 2, 2.0);
+}
+
+TEST(Matrix_Multiplication_Vertical, Big_Random_Matrix_Square) {
+    Image image = generate_random_image(202, 202);
+
+    base_test(image, 2, 2.0);
+}
+
+TEST(Matrix_Multiplication_Vertical, Empty_Image) {
+    Image image = generate_random_image(0, 0);
+
+    base_test(image, 1, 1.0);
+}
+
+int main(int argc, char** argv) {
+    boost::mpi::environment env(argc, argv);
+    boost::mpi::communicator world;
+    ::testing::InitGoogleTest(&argc, argv);
+    ::testing::TestEventListeners& listeners = ::testing::UnitTest::GetInstance()->listeners();
+
+    if (world.rank() != 0) {
+        delete listeners.Release(listeners.default_result_printer());
+    }
+
+    return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
Реализовано для произвольного радиуса ядра Гаусса `K x K`.

Изображение разбивается на `N x M` блоков, где `N` и `M` это два самых близких делителя числа кол-во процессов `world.size()` (например: для `24` это `4` и `6`) с помощью функции `boost::mpi::scatter`, это делается для того чтобы как можно ровнее разделить блоки.

После этого для каждого блока применяется последовательный алгоритм фильтрации, но без крайних границ (`K..N-K x K..M-K`).

Затем с помощью функции `boost::mpi::gather` блоки собираются в конечное изображение, и для каждого пикселя, который мы пропустили, применяется фильтр Гаусса.