### PR TITLE
Федотов Кирилл. Задача 2. Вариант 9. Обобщенная передача от всех одному (gather).

### DIFF
--- a/tasks/task_1/fedotov_k_word_count/CMakeLists.txt
+++ b/tasks/task_1/fedotov_k_word_count/CMakeLists.txt
@@ -1,0 +1,36 @@
+get_filename_component(ProjectId ${CMAKE_CURRENT_SOURCE_DIR} NAME)
+enable_testing()
+
+if( USE_MPI )
+    if( UNIX )
+        set(CMAKE_C_FLAGS  "${CMAKE_CXX_FLAGS} -Wno-uninitialized")
+        set(CMAKE_CXX_FLAGS  "${CMAKE_CXX_FLAGS} -Wno-uninitialized")
+    endif( UNIX )
+
+    set(ProjectId "${ProjectId}_mpi")
+    project( ${ProjectId} )
+    message( STATUS "-- " ${ProjectId} )
+
+    file(GLOB_RECURSE header_files "*.h")
+    file(GLOB_RECURSE source_files "*.cpp")
+    set(PACK_LIB "${ProjectId}_lib")
+    add_library(${PACK_LIB} STATIC ${header_files} ${source_files})
+
+    add_executable( ${ProjectId} ${source_files} )
+
+    target_link_libraries(${ProjectId} ${PACK_LIB})
+    if( MPI_COMPILE_FLAGS )
+        set_target_properties( ${ProjectId} PROPERTIES COMPILE_FLAGS "${MPI_COMPILE_FLAGS}" )
+    endif( MPI_COMPILE_FLAGS )
+
+    if( MPI_LINK_FLAGS )
+        set_target_properties( ${ProjectId} PROPERTIES LINK_FLAGS "${MPI_LINK_FLAGS}" )
+    endif( MPI_LINK_FLAGS )
+    target_link_libraries( ${ProjectId} ${MPI_LIBRARIES} )
+    target_link_libraries(${ProjectId} gtest gtest_main)
+
+    enable_testing()
+    add_test(NAME ${ProjectId} COMMAND ${ProjectId})
+else( USE_MPI )
+    message( STATUS "-- ${ProjectId} - NOT BUILD!"  )
+endif( USE_MPI )

--- a/tasks/task_1/fedotov_k_word_count/main.cpp
+++ b/tasks/task_1/fedotov_k_word_count/main.cpp
@@ -1,0 +1,74 @@
+// Copyright 2023 Fedotov Kirill
+#include <gtest/gtest.h>
+#include <mpi.h>
+#include <string>
+#include "../tasks/task_1/fedotov_k_word_count/word_count.h"
+
+TEST(word_count, sequentalCount) {
+  int rank;
+  MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+
+  if (rank == 0) {
+    std::string st = "MPI is live ";
+    int res = getLinearCount(st, st.size());
+    ASSERT_EQ(res, 3);
+  }
+}
+
+TEST(word_count, isLetter_with_capital_letter) {
+  int rank;
+  MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+
+  std::string st = "MPI is live ";
+  if (rank == 0) {
+    bool res = isLetter('A');
+    ASSERT_EQ(res, true);
+  }
+}
+
+TEST(word_count, isLetter_with_letter) {
+  int rank;
+  MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+
+  std::string st = "MPI is live ";
+  if (rank == 0) {
+    bool res = isLetter('a');
+    ASSERT_EQ(res, true);
+  }
+}
+
+TEST(word_count, isLetter_with_another_symbol) {
+  int rank;
+  MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+
+  std::string st = "MPI is live ";
+  if (rank == 0) {
+    bool res = isLetter(';');
+    ASSERT_EQ(res, false);
+  }
+}
+
+TEST(word_count, parallelCount) {
+  int rank;
+  MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+  std::string st;
+  if (rank == 0) {
+    randWord(&st, 99);
+  }
+  int res = getCount(st);
+
+  if (rank == 0) {
+    ASSERT_EQ(res, 99);
+  }
+}
+
+int main(int argc, char** argv) {
+    int resultCode = 0;
+    ::testing::InitGoogleTest(&argc, argv);
+    ::testing::TestEventListeners& listeners = ::testing::UnitTest::GetInstance()->listeners();
+    if (MPI_Init(&argc, &argv) != MPI_SUCCESS)
+            MPI_Abort(MPI_COMM_WORLD, -1);
+    resultCode = RUN_ALL_TESTS();
+    MPI_Finalize();
+    return resultCode;
+}

--- a/tasks/task_1/fedotov_k_word_count/word_count.cpp
+++ b/tasks/task_1/fedotov_k_word_count/word_count.cpp
@@ -1,0 +1,80 @@
+// Copyright 2023 Fedotov Kirill
+
+#include <mpi.h>
+#include <string>
+#include <vector>
+#include <random>
+#include <ctime>
+#include "../tasks/task_1/fedotov_k_word_count/word_count.h"
+
+
+bool isLetter(char sym) {
+  return (sym <= 'z' && sym >= 'a') || (sym <= 'Z' && sym >= 'A');
+}
+
+void randWord(std::string* st, int add_size) {
+  std::vector<std::string> vec{"MPI ", "size ", "vec "};
+  std::mt19937 gen(time(0));
+  for (int i = 0; i < add_size; i++) *st += vec[gen() % 3];
+}
+
+int getLinearCount(std::string st, int size) {
+  int count = 0;
+  bool flag = 0;
+  for (int i = 0; i < size; i++) {
+    if (isLetter(st[i]) == true) {
+      flag = 1;
+    } else {
+      if (flag == true) count++;
+      flag = false;
+    }
+  }
+
+  if (flag == true) count++;
+
+  return count;
+}
+
+
+int getCount(const std::string st) {
+  int size, rank;
+  MPI_Comm_size(MPI_COMM_WORLD, &size);
+  MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+
+  int vec_size = 0;
+  if (rank == 0) vec_size = st.size();
+
+  MPI_Bcast(&vec_size, 1, MPI_INT, 0, MPI_COMM_WORLD);
+
+  int local_count = 0;
+  int global_count;
+  int delta = vec_size / size;
+  int rem = vec_size % size;
+
+  if (rank == 0) {
+    for (int i = 1; i < size; i++) {
+      MPI_Send(&st[0] + i * delta + rem, delta, MPI_CHAR, i, 0, MPI_COMM_WORLD);
+    }
+  }
+
+  std::vector<char> local_st(delta);
+  if (rank == 0) {
+    local_st = std::vector<char>(st.begin(), st.begin() + delta + rem);
+    local_count =
+        getLinearCount(std::string(&local_st[0], delta + rem), delta + rem);
+  } else {
+    MPI_Status status;
+    MPI_Recv(&local_st[0], delta, MPI_CHAR, 0, 0, MPI_COMM_WORLD, &status);
+    local_count = getLinearCount(std::string(&local_st[0], delta), delta);
+  }
+
+  MPI_Reduce(&local_count, &global_count, 1, MPI_INT, MPI_SUM, 0,
+             MPI_COMM_WORLD);
+
+  if (rank == 0 && vec_size >= size) {
+    for (int i = 1; i < size; i++)
+      if (isLetter(st[i * delta + rem - 1]) && isLetter(st[i * delta + rem]))
+        global_count--;
+  }
+  return global_count;
+}

--- a/tasks/task_1/fedotov_k_word_count/word_count.h
+++ b/tasks/task_1/fedotov_k_word_count/word_count.h
@@ -1,0 +1,15 @@
+// Copyright 2023 Fedotov Kirill
+#ifndef TASKS_TASK_1_FEDOTOV_K_WORD_COUNT_WORD_COUNT_H_
+#define TASKS_TASK_1_FEDOTOV_K_WORD_COUNT_WORD_COUNT_H_
+
+#define EMPTY_STRING_ERROR -1
+
+#include <string>
+#include <vector>
+
+void randWord(std::string* st, int add_size);
+bool isLetter(char sym);
+int getCount(std::string st);
+int getLinearCount(std::string st, int size);
+
+#endif  // TASKS_TASK_1_FEDOTOV_K_WORD_COUNT_WORD_COUNT_H_

--- a/tasks/task_2/fedotov_k_gather/CMakeLists.txt
+++ b/tasks/task_2/fedotov_k_gather/CMakeLists.txt
@@ -1,0 +1,36 @@
+get_filename_component(ProjectId ${CMAKE_CURRENT_SOURCE_DIR} NAME)
+enable_testing()
+
+if( USE_MPI )
+    if( UNIX )
+        set(CMAKE_C_FLAGS  "${CMAKE_CXX_FLAGS} -Wno-uninitialized")
+        set(CMAKE_CXX_FLAGS  "${CMAKE_CXX_FLAGS} -Wno-uninitialized")
+    endif( UNIX )
+
+    set(ProjectId "${ProjectId}_mpi")
+    project( ${ProjectId} )
+    message( STATUS "-- " ${ProjectId} )
+
+    file(GLOB_RECURSE header_files "*.h")
+    file(GLOB_RECURSE source_files "*.cpp")
+    set(PACK_LIB "${ProjectId}_lib")
+    add_library(${PACK_LIB} STATIC ${header_files} ${source_files})
+
+    add_executable( ${ProjectId} ${source_files} )
+
+    target_link_libraries(${ProjectId} ${PACK_LIB})
+    if( MPI_COMPILE_FLAGS )
+        set_target_properties( ${ProjectId} PROPERTIES COMPILE_FLAGS "${MPI_COMPILE_FLAGS}" )
+    endif( MPI_COMPILE_FLAGS )
+
+    if( MPI_LINK_FLAGS )
+        set_target_properties( ${ProjectId} PROPERTIES LINK_FLAGS "${MPI_LINK_FLAGS}" )
+    endif( MPI_LINK_FLAGS )
+    target_link_libraries( ${ProjectId} ${MPI_LIBRARIES} )
+    target_link_libraries(${ProjectId} gtest gtest_main)
+
+    enable_testing()
+    add_test(NAME ${ProjectId} COMMAND ${ProjectId})
+else( USE_MPI )
+    message( STATUS "-- ${ProjectId} - NOT BUILD!"  )
+endif( USE_MPI )

--- a/tasks/task_2/fedotov_k_gather/CMakeLists.txt
+++ b/tasks/task_2/fedotov_k_gather/CMakeLists.txt
@@ -11,12 +11,12 @@ if( USE_MPI )
     project( ${ProjectId} )
     message( STATUS "-- " ${ProjectId} )
 
-    file(GLOB_RECURSE header_files "*.h")
-    file(GLOB_RECURSE source_files "*.cpp")
-    set(PACK_LIB "${ProjectId}_lib")
-    add_library(${PACK_LIB} STATIC ${header_files} ${source_files})
+    file(GLOB_RECURSE ALL_SOURCE_FILES *.cpp *.h)
 
-    add_executable( ${ProjectId} ${source_files} )
+    set(PACK_LIB "${ProjectId}_lib")
+    add_library(${PACK_LIB} STATIC ${ALL_SOURCE_FILES} )
+
+    add_executable( ${ProjectId} ${ALL_SOURCE_FILES} )
 
     target_link_libraries(${ProjectId} ${PACK_LIB})
     if( MPI_COMPILE_FLAGS )
@@ -27,10 +27,12 @@ if( USE_MPI )
         set_target_properties( ${ProjectId} PROPERTIES LINK_FLAGS "${MPI_LINK_FLAGS}" )
     endif( MPI_LINK_FLAGS )
     target_link_libraries( ${ProjectId} ${MPI_LIBRARIES} )
-    target_link_libraries(${ProjectId} gtest gtest_main)
+    target_link_libraries(${ProjectId} gtest gtest_main boost_mpi)
 
     enable_testing()
     add_test(NAME ${ProjectId} COMMAND ${ProjectId})
+
+    CPPCHECK_AND_COUNTS_TESTS("${ProjectId}" "${ALL_SOURCE_FILES}")
 else( USE_MPI )
     message( STATUS "-- ${ProjectId} - NOT BUILD!"  )
 endif( USE_MPI )

--- a/tasks/task_2/fedotov_k_gather/gather.cpp
+++ b/tasks/task_2/fedotov_k_gather/gather.cpp
@@ -1,0 +1,51 @@
+// Copyright 2023 Fedotov Kirill
+#include "task_2/fedotov_k_gather/gather.h"
+
+int Gather(const void* sendbuf, int sendcount, MPI_Datatype sendtype, void* recvbuf,
+    int recvcount, MPI_Datatype recvtype, int root, MPI_Comm comm) {
+    int numProc;
+    int rankProc;
+    MPI_Comm_size(comm, &numProc);
+    MPI_Comm_rank(comm, &rankProc);
+    int sizeofType = 0;
+    MPI_Type_size(sendtype, &sizeofType);
+
+    if (!(sendtype == MPI_INT || sendtype == MPI_FLOAT || sendtype == MPI_DOUBLE) ||
+        (sendcount <= 0 || recvcount <= 0 || root < 0 || root >= numProc)) throw - 1;
+
+    int previous = rankProc - 1;
+    int next = rankProc + 1;
+    int numbytes = sendcount * sizeofType;
+    void* tmpBuf = std::malloc(numbytes * (numProc - rankProc));
+    std::memcpy(tmpBuf, sendbuf, numbytes);
+
+    if (numProc == 1) {
+        std::memcpy(recvbuf, tmpBuf, numbytes);
+    } else {
+        if (rankProc != 0) {
+            if (next < numProc) {
+                MPI_Recv(reinterpret_cast<char*>(tmpBuf) + 1 * recvcount * sizeofType,
+                    recvcount * (numProc - rankProc - 1),
+                    sendtype, next, 0, comm, MPI_STATUS_IGNORE);
+                MPI_Send(tmpBuf, sendcount * (numProc - rankProc),
+                    sendtype, previous, 0, comm);
+            } else {
+                MPI_Send(tmpBuf, sendcount, sendtype, previous, 0, comm);
+            }
+        } else {
+            MPI_Recv(reinterpret_cast<char*>(tmpBuf) + 1 * recvcount * sizeofType,
+                recvcount * (numProc - rankProc - 1),
+                sendtype, next, 0, comm, MPI_STATUS_IGNORE);
+            if (rankProc == root) {
+                std::memcpy(recvbuf, tmpBuf, numbytes * (numProc - rankProc));
+            } else {
+                MPI_Send(tmpBuf, sendcount * numProc, sendtype, root, 0, comm);
+            }
+        }
+        if (rankProc == root && rankProc != 0) {
+            MPI_Recv(recvbuf, sendcount * numProc, sendtype, 0, 0, comm, MPI_STATUS_IGNORE);
+        }
+    }
+    free(tmpBuf);
+    return MPI_SUCCESS;
+}

--- a/tasks/task_2/fedotov_k_gather/gather.cpp
+++ b/tasks/task_2/fedotov_k_gather/gather.cpp
@@ -1,51 +1,40 @@
-// Copyright 2023 Fedotov Kirill
+// Copyright 2024 Fedotov Kirill
+#include <mpi.h>
+#include <algorithm>
 #include "task_2/fedotov_k_gather/gather.h"
 
-int Gather(const void* sendbuf, int sendcount, MPI_Datatype sendtype, void* recvbuf,
-    int recvcount, MPI_Datatype recvtype, int root, MPI_Comm comm) {
-    int numProc;
-    int rankProc;
-    MPI_Comm_size(comm, &numProc);
-    MPI_Comm_rank(comm, &rankProc);
-    int sizeofType = 0;
-    MPI_Type_size(sendtype, &sizeofType);
+using std::copy;
 
-    if (!(sendtype == MPI_INT || sendtype == MPI_FLOAT || sendtype == MPI_DOUBLE) ||
-        (sendcount <= 0 || recvcount <= 0 || root < 0 || root >= numProc)) throw - 1;
+// MPI_Gather
+int MPI_Gather_c(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
+                 void *recvbuf, int recvcount, MPI_Datatype recvtype,
+                 int root, MPI_Comm comm) {
+    int size, rank;
+    int sendtype_size, recvtype_size;
+    MPI_Comm_size(comm, &size);
+    MPI_Comm_rank(comm, &rank);
 
-    int previous = rankProc - 1;
-    int next = rankProc + 1;
-    int numbytes = sendcount * sizeofType;
-    void* tmpBuf = std::malloc(numbytes * (numProc - rankProc));
-    std::memcpy(tmpBuf, sendbuf, numbytes);
-
-    if (numProc == 1) {
-        std::memcpy(recvbuf, tmpBuf, numbytes);
-    } else {
-        if (rankProc != 0) {
-            if (next < numProc) {
-                MPI_Recv(reinterpret_cast<char*>(tmpBuf) + 1 * recvcount * sizeofType,
-                    recvcount * (numProc - rankProc - 1),
-                    sendtype, next, 0, comm, MPI_STATUS_IGNORE);
-                MPI_Send(tmpBuf, sendcount * (numProc - rankProc),
-                    sendtype, previous, 0, comm);
-            } else {
-                MPI_Send(tmpBuf, sendcount, sendtype, previous, 0, comm);
-            }
-        } else {
-            MPI_Recv(reinterpret_cast<char*>(tmpBuf) + 1 * recvcount * sizeofType,
-                recvcount * (numProc - rankProc - 1),
-                sendtype, next, 0, comm, MPI_STATUS_IGNORE);
-            if (rankProc == root) {
-                std::memcpy(recvbuf, tmpBuf, numbytes * (numProc - rankProc));
-            } else {
-                MPI_Send(tmpBuf, sendcount * numProc, sendtype, root, 0, comm);
-            }
-        }
-        if (rankProc == root && rankProc != 0) {
-            MPI_Recv(recvbuf, sendcount * numProc, sendtype, 0, 0, comm, MPI_STATUS_IGNORE);
-        }
+    if (MPI_Type_size(sendtype, &sendtype_size) == MPI_ERR_TYPE) {
+        return MPI_ERR_TYPE;
     }
-    free(tmpBuf);
+    if (MPI_Type_size(recvtype, &recvtype_size) == MPI_ERR_TYPE) {
+        return MPI_ERR_TYPE;
+    }
+
+    if (rank == root) {
+        copy(reinterpret_cast<const char*>(sendbuf),
+             reinterpret_cast<const char*>(sendbuf) + sendtype_size * sendcount,
+             reinterpret_cast<char*>(recvbuf) + recvcount * recvtype_size * root);
+        for (int i = 0; i < size; ++i) {
+            if (i == rank)
+                continue;
+            MPI_Status status;
+            MPI_Recv(reinterpret_cast<char*>(recvbuf) + recvcount * recvtype_size * i, recvcount,
+                     recvtype, i, 0, comm, &status);
+        }
+    } else {
+        MPI_Send(sendbuf, sendcount, sendtype, root, 0, comm);
+    }
+
     return MPI_SUCCESS;
 }

--- a/tasks/task_2/fedotov_k_gather/gather.h
+++ b/tasks/task_2/fedotov_k_gather/gather.h
@@ -1,13 +1,11 @@
-// Copyright 2023 Fedotov Kirill
+// Copyright 2024 Fedotov Kirill
 #ifndef TASKS_TASK_2_FEDOTOV_K_GATHER_GATHER_H_
 #define TASKS_TASK_2_FEDOTOV_K_GATHER_GATHER_H_
 
 #include <mpi.h>
-#include <cstring>
-#include <cstdlib>
-#include <iostream>
 
-int Gather(const void* sendbuf, int sendcount, MPI_Datatype sendtype, void* recvbuf, int recvcount,
-    MPI_Datatype recvtype, int root, MPI_Comm comm);
-
+int MPI_Gather_c(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
+                 void *recvbuf, int recvcount, MPI_Datatype recvtype,
+                 int root, MPI_Comm comm);
+                 
 #endif  // TASKS_TASK_2_FEDOTOV_K_GATHER_GATHER_H_

--- a/tasks/task_2/fedotov_k_gather/gather.h
+++ b/tasks/task_2/fedotov_k_gather/gather.h
@@ -7,5 +7,5 @@
 int MPI_Gather_c(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
                  void *recvbuf, int recvcount, MPI_Datatype recvtype,
                  int root, MPI_Comm comm);
-                 
+
 #endif  // TASKS_TASK_2_FEDOTOV_K_GATHER_GATHER_H_

--- a/tasks/task_2/fedotov_k_gather/gather.h
+++ b/tasks/task_2/fedotov_k_gather/gather.h
@@ -1,0 +1,11 @@
+// Copyright 2023 Fedotov Kirill
+#ifndef TASKS_TASK_2_FEDOTOV_K_GATHER_GATHER_H_
+#define TASKS_TASK_2_FEDOTOV_K_GATHER_GATHER_H_
+
+#include <mpi.h>
+
+int MPI_Gather_c(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
+                 void *recvbuf, int recvcount, MPI_Datatype recvtype,
+                 int root, MPI_Comm comm);
+
+#endif  // TASKS_TASK_2_FEDOTOV_K_GATHER_GATHER_H_

--- a/tasks/task_2/fedotov_k_gather/gather.h
+++ b/tasks/task_2/fedotov_k_gather/gather.h
@@ -3,9 +3,11 @@
 #define TASKS_TASK_2_FEDOTOV_K_GATHER_GATHER_H_
 
 #include <mpi.h>
+#include <cstring>
+#include <cstdlib>
+#include <iostream>
 
-int MPI_Gather_c(const void *sendbuf, int sendcount, MPI_Datatype sendtype,
-                 void *recvbuf, int recvcount, MPI_Datatype recvtype,
-                 int root, MPI_Comm comm);
+int Gather(const void* sendbuf, int sendcount, MPI_Datatype sendtype, void* recvbuf, int recvcount,
+    MPI_Datatype recvtype, int root, MPI_Comm comm);
 
 #endif  // TASKS_TASK_2_FEDOTOV_K_GATHER_GATHER_H_

--- a/tasks/task_2/fedotov_k_gather/main.cpp
+++ b/tasks/task_2/fedotov_k_gather/main.cpp
@@ -1,133 +1,171 @@
-// Copyright 2023 Fedotov Kirill
+// Copyright 2024 Fedotov Kirill
 #include <gtest/gtest.h>
 #include <mpi.h>
-#include <iostream>
+#include <vector>
 #include "./gather.h"
 
-TEST(TEST_GATHER, Test_1) {
-    int numProc;
-    int rank;
-    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
-    MPI_Comm_size(MPI_COMM_WORLD, &numProc);
+using std::vector;
 
-    std::vector<int> sendbuf = { 1 };
-    std::vector<int> recvbuf(numProc);
-    Gather(sendbuf.data(), 1, MPI_INT, recvbuf.data(), 1, MPI_INT, 0, MPI_COMM_WORLD);
+TEST(MPI_Gather_Custom, Same_Types) {
+    // Arrange
+    constexpr int ROOT = 0;
+    constexpr int SENDSIZE = 500;
+    int rank, size;
+    vector<int> sendbuf(SENDSIZE);
+    vector<int> recvbuf;
+    vector<int> exp;
+
+    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+    MPI_Comm_size(MPI_COMM_WORLD, &size);
+    int k = rank * sendbuf.size();
+    for (int& i : sendbuf) {
+        i = ++k;
+    }
     if (rank == 0) {
-        for (int i = 0; i < recvbuf.size(); i++)
-            EXPECT_EQ(1, recvbuf[i]);
+        recvbuf.resize(size * sendbuf.size());
+        exp.resize(recvbuf.size());
+    }
+
+    // Act
+    MPI_Gather_c(sendbuf.data(), sendbuf.size(), MPI_INT,
+                 recvbuf.data(), sendbuf.size(), MPI_INT, ROOT, MPI_COMM_WORLD);
+    MPI_Gather(sendbuf.data(), sendbuf.size(), MPI_INT,
+               exp.data(), sendbuf.size(), MPI_INT, ROOT, MPI_COMM_WORLD);
+
+    // Assert
+    if (rank == 0) {
+        ASSERT_EQ(exp, recvbuf);
     }
 }
 
-TEST(TEST_GATHER, Test_int) {
-    int numProc;
-    int rank;
+TEST(MPI_Gather_Custom, Derived_Types) {
+    // Arrange
+    constexpr int ROOT = 0;
+    constexpr int SENDSIZE = 1000;
+    int rank, size;
+    vector<int16_t> sendbuf(SENDSIZE);
+    vector<int> recvbuf;
+    vector<int> exp;
+
     MPI_Comm_rank(MPI_COMM_WORLD, &rank);
-    MPI_Comm_size(MPI_COMM_WORLD, &numProc);
-
-    std::vector<int> sendbuf(4);
-    for (int i = 0; i < sendbuf.size(); i++) sendbuf[i] = rank * 4 + i;
-    std::vector<int> recvbuf(numProc * sendbuf.size());
-
-    Gather(sendbuf.data(), sendbuf.size(), MPI_INT,
-        recvbuf.data(), sendbuf.size(), MPI_INT, 0, MPI_COMM_WORLD);
+    MPI_Comm_size(MPI_COMM_WORLD, &size);
+    int k = rank * sendbuf.size();
+    for (int16_t& i : sendbuf) {
+        i = ++k;
+    }
     if (rank == 0) {
-        for (int i = 0; i < recvbuf.size(); i++)
-            EXPECT_EQ(i, recvbuf[i]);
+        recvbuf.resize(size * sendbuf.size() / 2);
+        exp.resize(recvbuf.size());
+    }
+
+    // Act
+    MPI_Gather_c(sendbuf.data(), sendbuf.size(), MPI_SHORT,
+                 recvbuf.data(), sendbuf.size() / 2, MPI_INT, ROOT, MPI_COMM_WORLD);
+    MPI_Gather(sendbuf.data(), sendbuf.size(), MPI_SHORT,
+               exp.data(), sendbuf.size() / 2, MPI_INT, ROOT, MPI_COMM_WORLD);
+
+    // Assert
+    if (rank == 0) {
+        ASSERT_EQ(exp, recvbuf);
     }
 }
 
-TEST(TEST_GATHER, Test_float) {
-    int numProc;
-    int rank;
+TEST(MPI_Gather_Custom, Recieve_Comp_Type) {
+    // Arrange
+    constexpr int ROOT = 0;
+    constexpr int SENDSIZE = 500;
+    int rank, size;
+    MPI_Datatype comptype;
+    vector<int> sendbuf(SENDSIZE);
+    vector<int> recvbuf;
+    vector<int> exp;
+
+    MPI_Type_contiguous(sendbuf.size(), MPI_INT, &comptype);
+    MPI_Type_commit(&comptype);
     MPI_Comm_rank(MPI_COMM_WORLD, &rank);
-    MPI_Comm_size(MPI_COMM_WORLD, &numProc);
-
-    std::vector<float> sendbuf(4);
-    for (int i = 0; i < sendbuf.size(); i++) sendbuf[i] = rank * 4 + i + 0.5;
-    std::vector<float> recvbuf(numProc * sendbuf.size());
-
-    Gather(sendbuf.data(), sendbuf.size(), MPI_FLOAT,
-        recvbuf.data(), sendbuf.size(), MPI_FLOAT, 0, MPI_COMM_WORLD);
+    MPI_Comm_size(MPI_COMM_WORLD, &size);
+    int k = rank * sendbuf.size();
+    for (int& i : sendbuf) {
+        i = ++k;
+    }
     if (rank == 0) {
-        for (int i = 0; i < recvbuf.size(); i++)
-            EXPECT_EQ(i + 0.5, recvbuf[i]);
+        recvbuf.resize(size * sendbuf.size());
+        exp.resize(recvbuf.size());
+    }
+
+    // Act
+    MPI_Gather_c(sendbuf.data(), sendbuf.size(), MPI_INT, recvbuf.data(), 1, comptype, ROOT, MPI_COMM_WORLD);
+    MPI_Gather(sendbuf.data(), sendbuf.size(), MPI_INT, exp.data(), 1, comptype, ROOT, MPI_COMM_WORLD);
+
+    // Assert
+    if (rank == 0) {
+        ASSERT_EQ(exp, recvbuf);
     }
 }
 
-TEST(TEST_GATHER, Test_double) {
-    int numProc;
-    int rank;
+TEST(MPI_Gather_Custom, Same_Comp_Types) {
+    // Arrange
+    constexpr int ROOT = 0;
+    constexpr int SENDSIZE = 500;
+    int rank, size;
+    MPI_Datatype comptype;
+    vector<int> sendbuf(SENDSIZE);
+    vector<int> recvbuf;
+    vector<int> exp;
+
+    MPI_Type_contiguous(sendbuf.size(), MPI_INT, &comptype);
+    MPI_Type_commit(&comptype);
     MPI_Comm_rank(MPI_COMM_WORLD, &rank);
-    MPI_Comm_size(MPI_COMM_WORLD, &numProc);
-
-    std::vector<double> sendbuf(4);
-    for (int i = 0; i < sendbuf.size(); i++) sendbuf[i] =  rank * 4 + i + 0.5;
-    std::vector<double> recvbuf(numProc * sendbuf.size());
-
-    Gather(sendbuf.data(), sendbuf.size(), MPI_DOUBLE,
-        recvbuf.data(), sendbuf.size(), MPI_DOUBLE, 0, MPI_COMM_WORLD);
+    MPI_Comm_size(MPI_COMM_WORLD, &size);
+    int k = rank * sendbuf.size();
+    for (int& i : sendbuf) {
+        i = ++k;
+    }
     if (rank == 0) {
-        for (int i = 0; i < recvbuf.size(); i++)
-            EXPECT_EQ(i + 0.5, recvbuf[i]);
+        recvbuf.resize(size * sendbuf.size());
+        exp.resize(recvbuf.size());
+    }
+
+    // Act
+    MPI_Gather_c(sendbuf.data(), 1, comptype, recvbuf.data(), 1, comptype, ROOT, MPI_COMM_WORLD);
+    MPI_Gather(sendbuf.data(), 1, comptype, exp.data(), 1, comptype, ROOT, MPI_COMM_WORLD);
+
+    // Assert
+    if (rank == 0) {
+        ASSERT_EQ(exp, recvbuf);
     }
 }
 
-TEST(TEST_GATHER, Test_time) {
-    int numProc;
-    int rank;
+TEST(MPI_Gather_Custom, Send_Comp_Type) {
+    // Arrange
+    constexpr int ROOT = 0;
+    constexpr int SENDSIZE = 500;
+    int rank, size;
+    MPI_Datatype comptype;
+    vector<int> sendbuf(SENDSIZE);
+    vector<int> recvbuf;
+    vector<int> exp;
+
+    MPI_Type_contiguous(sendbuf.size(), MPI_INT, &comptype);
+    MPI_Type_commit(&comptype);
     MPI_Comm_rank(MPI_COMM_WORLD, &rank);
-    MPI_Comm_size(MPI_COMM_WORLD, &numProc);
-
-    std::vector<float> sendbuf(4);
-    for (int i = 0; i < sendbuf.size(); i++) sendbuf[i] =  rank * 4 + i + 0.5;
-    std::vector<float> recvbuf(numProc * sendbuf.size());
-    std::vector<float> recvbuf2(numProc * sendbuf.size());
-    double time1, time2, time3;
-    if (rank == 0)time1 = MPI_Wtime();
-    Gather(sendbuf.data(), sendbuf.size(), MPI_FLOAT,
-        recvbuf.data(), sendbuf.size(), MPI_FLOAT, 0, MPI_COMM_WORLD);
-
-    if (rank == 0)time2 = MPI_Wtime();
-    MPI_Gather(sendbuf.data(), sendbuf.size(), MPI_FLOAT,
-        recvbuf2.data(), sendbuf.size(), MPI_FLOAT, 0, MPI_COMM_WORLD);
-    if (rank == 0) {
-        time3 = MPI_Wtime();
-        std::cout << "Gather time = " << time2 - time1
-            << std::endl << "MPI_Gather time = " << time3 - time2 << std::endl;
-        for (int i = 0; i < recvbuf.size(); i++) {
-            EXPECT_EQ(i + 0.5, recvbuf[i]);
-            EXPECT_EQ(i + 0.5, recvbuf2[i]);
-        }
+    MPI_Comm_size(MPI_COMM_WORLD, &size);
+    int k = rank * sendbuf.size();
+    for (int& i : sendbuf) {
+        i = ++k;
     }
-}
-
-TEST(TEST_GATHER, Test_wrong_root) {
-    int numProc;
-    int rank;
-    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
-    MPI_Comm_size(MPI_COMM_WORLD, &numProc);
-    std::vector<int> sendbuf(4);
-    for (int i = 0; i < sendbuf.size(); i++) sendbuf[i] = rank * 4 + i;
-    std::vector<int> recvbuf(numProc * sendbuf.size());
     if (rank == 0) {
-        EXPECT_ANY_THROW(Gather(sendbuf.data(), sendbuf.size(), MPI_INT,
-            recvbuf.data(), sendbuf.size(), MPI_INT, -1, MPI_COMM_WORLD));
+        recvbuf.resize(size * sendbuf.size());
+        exp.resize(recvbuf.size());
     }
-}
 
-TEST(TEST_GATHER, Test_wrong_type) {
-    int numProc;
-    int rank;
-    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
-    MPI_Comm_size(MPI_COMM_WORLD, &numProc);
+    // Act
+    MPI_Gather_c(sendbuf.data(), 1, comptype, recvbuf.data(), sendbuf.size(), MPI_INT, ROOT, MPI_COMM_WORLD);
+    MPI_Gather(sendbuf.data(), 1, comptype, exp.data(), sendbuf.size(), MPI_INT, ROOT, MPI_COMM_WORLD);
 
-    std::vector<int> sendbuf(4);
-    for (int i = 0; i < sendbuf.size(); i++) sendbuf[i] = rank * 4 + i;
-    std::vector<int> recvbuf(numProc * sendbuf.size());
+    // Assert
     if (rank == 0) {
-        EXPECT_ANY_THROW(Gather(sendbuf.data(), sendbuf.size(), MPI_CHAR,
-            recvbuf.data(), sendbuf.size(), MPI_CHAR, 0, MPI_COMM_WORLD));
+        ASSERT_EQ(exp, recvbuf);
     }
 }
 

--- a/tasks/task_2/fedotov_k_gather/main.cpp
+++ b/tasks/task_2/fedotov_k_gather/main.cpp
@@ -1,0 +1,186 @@
+// Copyright 2023 Fedotov Kirill
+
+#include <gtest/gtest.h>
+#include <mpi.h>
+#include <vector>
+#include "./gather.h"
+
+using std::vector;
+
+TEST(MPI_Gather_Custom, Same_Types) {
+    // Arrange
+    constexpr int ROOT = 0;
+    constexpr int SENDSIZE = 500;
+    int rank, size;
+    vector<int> sendbuf(SENDSIZE);
+    vector<int> recvbuf;
+    vector<int> exp;
+
+    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+    MPI_Comm_size(MPI_COMM_WORLD, &size);
+    int k = rank * sendbuf.size();
+    for (int& i : sendbuf) {
+        i = ++k;
+    }
+    if (rank == 0) {
+        recvbuf.resize(size * sendbuf.size());
+        exp.resize(recvbuf.size());
+    }
+
+    // Act
+    MPI_Gather_c(sendbuf.data(), sendbuf.size(), MPI_INT,
+                 recvbuf.data(), sendbuf.size(), MPI_INT, ROOT, MPI_COMM_WORLD);
+    MPI_Gather(sendbuf.data(), sendbuf.size(), MPI_INT,
+               exp.data(), sendbuf.size(), MPI_INT, ROOT, MPI_COMM_WORLD);
+
+    // Assert
+    if (rank == 0) {
+        ASSERT_EQ(exp, recvbuf);
+    }
+}
+
+TEST(MPI_Gather_Custom, Derived_Types) {
+    // Arrange
+    constexpr int ROOT = 0;
+    constexpr int SENDSIZE = 1000;
+    int rank, size;
+    vector<int16_t> sendbuf(SENDSIZE);
+    vector<int> recvbuf;
+    vector<int> exp;
+
+    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+    MPI_Comm_size(MPI_COMM_WORLD, &size);
+    int k = rank * sendbuf.size();
+    for (int16_t& i : sendbuf) {
+        i = ++k;
+    }
+    if (rank == 0) {
+        recvbuf.resize(size * sendbuf.size() / 2);
+        exp.resize(recvbuf.size());
+    }
+
+    // Act
+    MPI_Gather_c(sendbuf.data(), sendbuf.size(), MPI_SHORT,
+                 recvbuf.data(), sendbuf.size() / 2, MPI_INT, ROOT, MPI_COMM_WORLD);
+    MPI_Gather(sendbuf.data(), sendbuf.size(), MPI_SHORT,
+               exp.data(), sendbuf.size() / 2, MPI_INT, ROOT, MPI_COMM_WORLD);
+
+    // Assert
+    if (rank == 0) {
+        ASSERT_EQ(exp, recvbuf);
+    }
+}
+
+TEST(MPI_Gather_Custom, Recieve_Comp_Type) {
+    // Arrange
+    constexpr int ROOT = 0;
+    constexpr int SENDSIZE = 500;
+    int rank, size;
+    MPI_Datatype comptype;
+    vector<int> sendbuf(SENDSIZE);
+    vector<int> recvbuf;
+    vector<int> exp;
+
+    MPI_Type_contiguous(sendbuf.size(), MPI_INT, &comptype);
+    MPI_Type_commit(&comptype);
+    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+    MPI_Comm_size(MPI_COMM_WORLD, &size);
+    int k = rank * sendbuf.size();
+    for (int& i : sendbuf) {
+        i = ++k;
+    }
+    if (rank == 0) {
+        recvbuf.resize(size * sendbuf.size());
+        exp.resize(recvbuf.size());
+    }
+
+    // Act
+    MPI_Gather_c(sendbuf.data(), sendbuf.size(), MPI_INT, recvbuf.data(), 1, comptype, ROOT, MPI_COMM_WORLD);
+    MPI_Gather(sendbuf.data(), sendbuf.size(), MPI_INT, exp.data(), 1, comptype, ROOT, MPI_COMM_WORLD);
+
+    // Assert
+    if (rank == 0) {
+        ASSERT_EQ(exp, recvbuf);
+    }
+}
+
+TEST(MPI_Gather_Custom, Same_Comp_Types) {
+    // Arrange
+    constexpr int ROOT = 0;
+    constexpr int SENDSIZE = 500;
+    int rank, size;
+    MPI_Datatype comptype;
+    vector<int> sendbuf(SENDSIZE);
+    vector<int> recvbuf;
+    vector<int> exp;
+
+    MPI_Type_contiguous(sendbuf.size(), MPI_INT, &comptype);
+    MPI_Type_commit(&comptype);
+    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+    MPI_Comm_size(MPI_COMM_WORLD, &size);
+    int k = rank * sendbuf.size();
+    for (int& i : sendbuf) {
+        i = ++k;
+    }
+    if (rank == 0) {
+        recvbuf.resize(size * sendbuf.size());
+        exp.resize(recvbuf.size());
+    }
+
+    // Act
+    MPI_Gather_c(sendbuf.data(), 1, comptype, recvbuf.data(), 1, comptype, ROOT, MPI_COMM_WORLD);
+    MPI_Gather(sendbuf.data(), 1, comptype, exp.data(), 1, comptype, ROOT, MPI_COMM_WORLD);
+
+    // Assert
+    if (rank == 0) {
+        ASSERT_EQ(exp, recvbuf);
+    }
+}
+
+TEST(MPI_Gather_Custom, Send_Comp_Type) {
+    // Arrange
+    constexpr int ROOT = 0;
+    constexpr int SENDSIZE = 500;
+    int rank, size;
+    MPI_Datatype comptype;
+    vector<int> sendbuf(SENDSIZE);
+    vector<int> recvbuf;
+    vector<int> exp;
+
+    MPI_Type_contiguous(sendbuf.size(), MPI_INT, &comptype);
+    MPI_Type_commit(&comptype);
+    MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+    MPI_Comm_size(MPI_COMM_WORLD, &size);
+    int k = rank * sendbuf.size();
+    for (int& i : sendbuf) {
+        i = ++k;
+    }
+    if (rank == 0) {
+        recvbuf.resize(size * sendbuf.size());
+        exp.resize(recvbuf.size());
+    }
+
+    // Act
+    MPI_Gather_c(sendbuf.data(), 1, comptype, recvbuf.data(), sendbuf.size(), MPI_INT, ROOT, MPI_COMM_WORLD);
+    MPI_Gather(sendbuf.data(), 1, comptype, exp.data(), sendbuf.size(), MPI_INT, ROOT, MPI_COMM_WORLD);
+
+    // Assert
+    if (rank == 0) {
+        ASSERT_EQ(exp, recvbuf);
+    }
+}
+
+int main(int argc, char** argv) {
+    ::testing::InitGoogleTest(&argc, argv);
+    MPI_Init(&argc, &argv);
+
+    ::testing::AddGlobalTestEnvironment(new GTestMPIListener::MPIEnvironment);
+    ::testing::TestEventListeners& listeners =
+        ::testing::UnitTest::GetInstance()->listeners();
+
+    listeners.Release(listeners.default_result_printer());
+    listeners.Release(listeners.default_xml_generator());
+
+    listeners.Append(new GTestMPIListener::MPIMinimalistPrinter);
+    return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
Реализована своя версия MPI_Gather, используя MPI_Recv и MPI_Send.
MPI_Gather собирает данные на одном процессе. Для
получения всех собираемых данных на каждом процессе
нужно использовать функцию сбора и рассылки. Функция MPI_Recv выполняет операцию получения и не возвращается, пока не будет получено соответствующее сообщение. Функция MPI_Send выполняет операцию отправки в стандартном режиме и возвращает, когда буфер отправки можно безопасно использовать повторно. Функция MPI_Gather_c принимает указатель на начало буфера, содержащего данные для отправки в корневой процесс, количество элементов в буфере отправки, тип данных элементов в буфере, указатель на буфер корневого процесса, содержащий полученные данные от каждого процесса, количество элементов, полученных от каждого процесса, тип данных элементов в буфере корневого процесса, ранг принимающего процесса в коммуникаторе и сам коммуникатор. Если операция завершилась успешно, функция возвращает MPI_SUCCESS, в противном случае - код ошибки. После сравнения MPI_Gather_c и MPI_Gather выяснилось, что оригинальная функция MPI_Gather выполняется быстрее.